### PR TITLE
Fix fontawesome class of email icon

### DIFF
--- a/layouts/partials/home/social.html
+++ b/layouts/partials/home/social.html
@@ -161,5 +161,5 @@
     <a href="https://mastodon.social/{{ . }}" rel="me noopener noreffer" target="_blank"><i class="fab fa-mastodon fa-fw"></i></a>
 {{ end }}
 {{ with .Site.Params.Social.Email}}
-    <a href="mailto:{{.}}" rel="me noopener noreffer"><i class="far fa-envelope" target="_blank fa-fw"></i></a>
+    <a href="mailto:{{.}}" rel="me noopener noreffer"><i class="far fa-envelope fa-fw" target="_blank"></i></a>
 {{ end }}


### PR DESCRIPTION
A fontawesome class (`fa-fw`) in an email icon is written in a wrong place, which results in wrong icon width compared to others. This PR fixed it.