### PR TITLE
Edit Mastodon's URL

### DIFF
--- a/layouts/partials/home/social.html
+++ b/layouts/partials/home/social.html
@@ -269,7 +269,7 @@
     </a>
 {{- end -}}
 {{- with .Site.Params.Social.Mastodon}}
-    <a href="https://mastodon.social/{{ . }}" rel="me noopener noreffer" target="_blank">
+    <a href="{{ . }}" rel="me noopener noreffer" target="_blank">
         <i class="fab fa-mastodon fa-fw" title="Mastodon"></i>
     </a>
 {{- end -}}

--- a/layouts/partials/home/social.html
+++ b/layouts/partials/home/social.html
@@ -270,7 +270,7 @@
 {{- end -}}
 {{- with .Site.Params.Social.Mastodon}}
     <a href="{{ . }}" rel="me noopener noreffer" target="_blank">
-        <i class="fab fa-mastodon fa-fw" title="Mastodon"></i>
+        <i class="fab fa fa-mastodon fa-fw" title="Mastodon"></i>
     </a>
 {{- end -}}
 {{- with .Site.Params.Social.Devto}}


### PR DESCRIPTION
As mastodon is a decentralized and federated network. There are many Mastodon instances like: [mastodon.technology](https://mastodon.technology/about), [floss.social](https://floss.social/about), [linuxrocks.online](https://linuxrocks.online/about),.. Mastodon.social is only one of those instances, so I think it's best to let user enter their own URL account.