### PR TITLE
Fix path to custom CSS in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ A few suggestions to help you get a good looking site quickly:
 
 If you want to change some styling to fit your own website needs, you can edit them:
 
-* `assets/css/_varibales.scss`: You can override the variables in `_variables.scss` to customize the style
-* `assets/css/_custom.scss`: You can put your custom css in this file
+* `config/css/_varibales.scss`: You can override the variables in `_variables.scss` to customize the style
+* `config/css/_custom.scss`: You can put your custom css in this file
 
 ## Favicons, Browserconfig, Manifest
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -132,8 +132,8 @@
 
 如果你想改变一些网站样式来满足你的需求，你可以编辑：
 
-* `assets/css/_varibales.scss`： 你可以覆盖 `_variables.scss` 中的变量来自定义样式
-* `assets/css/_custom.scss`： 你可以把自定义的样式放在这个文件
+* `config/css/_varibales.scss`： 你可以覆盖 `_variables.scss` 中的变量来自定义样式
+* `config/css/_custom.scss`： 你可以把自定义的样式放在这个文件
 * 需要使用hugo extended版本编译sass，否则修改css无法生效
 
 ## 网站图标、浏览器配置、网站清单


### PR DESCRIPTION
Hi @dillonzq, thank you for creating this wonderful theme.

In the README, it mentions that we should place our custom CSS files in `assets/css/` but I found out that those files should be placed in `config/css` as shown in the [exampleSite](https://github.com/dillonzq/LoveIt/tree/develop/exampleSite). This PR is a proposal to fix the inconsistency mentioned above.

Thanks!