### PR TITLE
Add fathom analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ I hope you will LoveIt ❤️!
 * Optimized for **performance**: 99/100 on mobile and 100/100 on desktop in [Google PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights)
 * Optimized SEO performance with a correct **SEO SCHEMA** based on JSON-LD
 * [**Google Analytics**](https://analytics.google.com/analytics) support
+* [**Fathom Analytics**](https://usefathom.com/) support
 * Search engine **verification** support (Google, Bind, Yandex and Baidu)
 * **CDN** for third-party libraries support
 * Automatically converted images with **Lazy Load** by [lazysizes](https://github.com/aFarkas/lazysizes)

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -756,6 +756,11 @@ enableEmoji = true
     yandex = ""
     pinterest = ""
     baidu = ""
+  [params.fathomAnalytics]
+    # siteID = "ABC123"
+    # If you're self hosting use this for your tracker
+    # serverURL = "https://example.com"
+
   # Publisher Info just for SEO
   # 出版者信息，仅用于 SEO
   [params.publisher]

--- a/layouts/partials/assets.html
+++ b/layouts/partials/assets.html
@@ -245,4 +245,8 @@
 {{- /* Google analytics async */ -}}
 {{- if $scratch.Get "production" | and .Site.GoogleAnalytics -}}
     {{- template "_internal/google_analytics_async.html" . -}}
+
+    {{ if and .Site.Params.fathomAnalytics .Site.Params.fathomAnalytics.siteID }}
+        {{- partial "plugin/analytics/fathom" . -}}
+    {{ end }}
 {{- end -}}

--- a/layouts/partials/plugin/analytics/fathom.html
+++ b/layouts/partials/plugin/analytics/fathom.html
@@ -1,0 +1,13 @@
+<script>
+    (function(f, a, t, h, o, m){
+        a[h]=a[h]||function(){
+            (a[h].q=a[h].q||[]).push(arguments)
+        };
+        o=f.createElement('script'),
+        m=f.getElementsByTagName('script')[0];
+        o.async=1; o.src=t; o.id='fathom-script';
+        m.parentNode.insertBefore(o,m)
+    })(document, window, '//{{ .Site.Params.fathomAnalytics.serverURL | default "cdn.usefathom.com" }}/tracker.js', 'fathom');
+    fathom('set', 'siteId', '{{ .Site.Params.fathomAnalytics.siteID }}');
+    fathom('trackPageview');
+</script>


### PR DESCRIPTION
Add Fathom analytics to be used alongside or exclusively w/ Google Analytics, fix #196 