### PR TITLE
fix: 修复 toc 设置不能正确识别的问题

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -4,10 +4,10 @@
     {{- $params := .Scratch.Get "params" -}}
 
     {{- /* Auto TOC */ -}}
-    {{- if ne $params.toc.enable false -}}
+    {{- if ne $params.page.toc.enable false -}}
         <div class="toc" id="toc-auto">
             <h2 class="toc-title">{{ T "contents" }}</h2>
-            <div class="toc-content{{ if eq $params.toc.auto false }} always-active{{ end }}" id="toc-content-auto"></div>
+            <div class="toc-content{{ if eq $params.page.toc.auto false }} always-active{{ end }}" id="toc-content-auto"></div>
         </div>
     {{- end -}}
 
@@ -66,7 +66,7 @@
         {{- end -}}
 
         {{- /* Static TOC */ -}}
-        {{- if ne $params.toc.enable false -}}
+        {{- if ne $params.page.toc.enable false -}}
             <div class="details toc" id="toc-static">
                 <div class="details-summary toc-title">
                     <span>{{ T "contents" }}</span>


### PR DESCRIPTION
新版本的主题设置结构更改，但是模板中并没有做同样的更改，导致无法编译生成页面。这里修复了这个问题。

The new 0.2.X changed structure of settings in config.toml file. And this cause a problem that prevents page compilation. This had fixed it.