### PR TITLE
Fix(comments): Updated params variable

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,7 @@
     {{- end -}}
 {{- end -}}
 
-{{- $params := .Params | merge .Site.Params.page -}}
+{{- $params := .Site.Params | merge .Site.Params.page -}}
 {{- .Scratch.Set "version" "0.2.6" -}}
 
 {{- if eq hugo.Environment "production" -}}


### PR DESCRIPTION
There is an error assigning the `$params` variable which is used for setting the comment variable. For this reason, the comment section is not working.

Fixes https://github.com/dillonzq/LoveIt/issues/338