### PR TITLE
Add option to enable linked GoogleTagManager

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -34,8 +34,6 @@ enableEmoji = true
     hasCJKLanguage = false
     # default amount of posts in each pages
     paginate = 12
-    # [UA-XXXXXXXX-X] google analytics code
-    googleAnalytics = ""
     # copyright description used only for seo schema
     copyright = "This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License."
     # Menu config
@@ -236,8 +234,6 @@ enableEmoji = true
     hasCJKLanguage = true
     # 默认每页列表显示的文章数目
     paginate = 12
-    # [UA-XXXXXXXX-X] 谷歌分析代号
-    googleAnalytics = ""
     # 版权描述，仅仅用于 SEO
     copyright = "This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License."
     # 菜单配置
@@ -434,8 +430,6 @@ enableEmoji = true
     hasCJKLanguage = false
     # default amount of posts in each pages
     paginate = 12
-    # [UA-XXXXXXXX-X] google analytics code
-    googleAnalytics = ""
     # copyright description used only for seo schema
     copyright = "This work is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License."
     # Menu config
@@ -989,7 +983,12 @@ enableEmoji = true
     enable = false
     # Google Analytics
     [params.analytics.google]
+      # [UA-XXXXXXXX-X] google analytics code
+      # [UA-XXXXXXXX-X] 谷歌分析代号
       id = ""
+      # whether to use gtag linked
+      # 是否使用gtag链接
+      gtag = false
       # whether to anonymize IP
       # 是否匿名化用户 IP
       anonymizeIP = true

--- a/layouts/partials/plugin/analytics.html
+++ b/layouts/partials/plugin/analytics.html
@@ -3,11 +3,24 @@
 {{- if $analytics.enable -}}
     {{- /* Google Analytics */ -}}
     {{- with $analytics.google.id -}}
-        <script type="text/javascript">
-            window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());
-            gtag('config', '{{ . }}'{{ if $analytics.google.anonymizeIP }}, { 'anonymize_ip': true }{{ end }});
-        </script>
-        {{- printf "https://www.googletagmanager.com/gtag/js?id=%v" . | dict "Async" true "Source" | partial "plugin/script.html" -}}
+        {{- if $analytics.google.gtag -}}
+            <script type="text/javascript">
+                window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());
+                gtag('config', '{{ . }}'{{ if $analytics.google.anonymizeIP }}, { 'anonymize_ip': true }{{ end }});
+            </script>
+            {{- printf "https://www.googletagmanager.com/gtag/js?id=%v" . | dict "Async" true "Source" | partial "plugin/script.html" -}}
+        {{- else -}}
+	    <script>
+                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+	        ga('create', '{{ . }}', 'auto');
+	        {{ if $analytics.google.anonymizeIP }}ga('set', 'anonymizeIp', true);{{ end }}
+	        ga('send', 'pageview');
+	    </script>
+        {{- end -}}
     {{- end -}}
 
     {{- /* Fathom Analytics */ -}}


### PR DESCRIPTION
Not all users linked their GoogleAnalytics with the GoogleTagManager, add option whether to use GoogleTagManager or not. This also remove deprecated googleAnalytics config.