### PR TITLE
Add Reference to Hugo Internal Template Google Analytics

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,6 +14,7 @@
         {{- partial "head/meta.html" . -}}
         {{- partial "head/link.html" . -}}
         {{- partial "head/seo.html" . -}}
+        {{ template "_internal/google_analytics.html" . }}
     </head>
     <body header-desktop="{{ .Site.Params.header.desktopMode }}" header-mobile="{{ .Site.Params.header.mobileMode }}">
         {{- /* Check theme isDark before body rendering */ -}}


### PR DESCRIPTION
I noticed Google Analytics wasn't monitoring my site's traffic. After a little digging, I found that the theme wasn't calling the internal Hugo template so the tag was never being generated.