### PR TITLE
fix: wrap date in posts page

### DIFF
--- a/assets/css/_partial/_archive/_terms.scss
+++ b/assets/css/_partial/_archive/_terms.scss
@@ -68,7 +68,7 @@
 }
 
 .archive-item-date {
-  width: 4em;
+  width: 6em;
   text-align: right;
   color: $global-font-secondary-color;
 


### PR DESCRIPTION
this fixes the date wrap when enabling custom date format in the posts page.  

**Before**
![before](https://user-images.githubusercontent.com/5076760/87247123-6f8ac200-c46f-11ea-968a-55e8199fd8ca.png)

**After**
![after](https://user-images.githubusercontent.com/5076760/87247129-7c0f1a80-c46f-11ea-9253-1673583eda8b.png)
