### PR TITLE
feat(gitalk): added admin option

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -860,6 +860,7 @@ enableEmoji = true
       [params.page.comment.gitalk]
         enable = false
         owner = ""
+        admin = [""]
         repo = ""
         clientId = ""
         clientSecret = ""

--- a/exampleSite/content/posts/theme-documentation-basics/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.en.md
@@ -508,6 +508,8 @@ Please open the code block below to view the complete sample configuration :(far
         # {{< version 0.1.1 >}}
         enable = false
         owner = ""
+        # {{< version 0.2.11 >}}
+        admin = [""]
         repo = ""
         clientId = ""
         clientSecret = ""

--- a/exampleSite/content/posts/theme-documentation-basics/index.fr.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.fr.md
@@ -513,6 +513,8 @@ Please open the code block below to view the complete sample configuration :(far
         # {{< version 0.1.1 >}}
         enable = false
         owner = ""
+        # {{< version 0.2.11 >}}
+        admin = [""]
         repo = ""
         clientId = ""
         clientSecret = ""

--- a/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
@@ -511,6 +511,8 @@ hugo
         # {{< version 0.1.1 >}}
         enable = false
         owner = ""
+        # {{< version 0.2.11 >}}
+        admin = [""]
         repo = ""
         clientId = ""
         clientSecret = ""

--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -24,7 +24,7 @@
             {{- dict "Source" $source "Minify" true "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
             {{- $source := $cdn.gitalkJS | default "lib/gitalk/gitalk.min.js" -}}
             {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
-            {{- $commentConfig = dict "id" .Date "title" .Title "clientID" $gitalk.clientId "clientSecret" $gitalk.clientSecret "repo" $gitalk.repo "owner" $gitalk.owner "admin" (slice $gitalk.owner $gitalk.admin) | dict "gitalk" | merge $commentConfig -}}
+            {{- $commentConfig = dict "id" .Date "title" .Title "clientID" $gitalk.clientId "clientSecret" $gitalk.clientSecret "repo" $gitalk.repo "owner" $gitalk.owner "admin" $gitalk.admin | dict "gitalk" | merge $commentConfig -}}
             <noscript>
                 Please enable JavaScript to view the comments powered by <a href="https://github.com/gitalk/gitalk"></a>Gitalk</a>.
             </noscript>


### PR DESCRIPTION
Hi!

I think we should add the `admin` option for the `gitalk` comment system.

Regarding the [official documentation](https://github.com/gitalk/gitalk#options) of `Gitalk`, the `admin` parameter is required.

For example, I have a repository assigned to the organizational account. Then the owner of the repository is the organizational account, but in blog I connect with the Github private account, the latter having rights over the organizational account.

I would like the configuration to this comment system to have the `admin` option (array) to set the users with the write access to this repository.