### PR TITLE
`.params` -> `$params`

### DIFF
--- a/layouts/partials/rss/item.html
+++ b/layouts/partials/rss/item.html
@@ -10,7 +10,7 @@
         {{- .Page.Date.Format "Mon, 02 Jan 2006 15:04:05 -0700"  -}}
     </pubDate>
     <author>
-        {{- .params.author | default (T "author") -}}
+        {{- $params.author | default (T "author") -}}
     </author>
     <guid>
         {{- .Page.Permalink -}}


### PR DESCRIPTION
This was causing the authors of all RSS items to render as "Author".