### PR TITLE
add more markdown images to gallery when lightgallery is enabled

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,10 +1,16 @@
-{{- if .Title -}}
+{{ $figcap := or .Title .Text }}
+{{ $caption := or .Text " " }}
+{{- if eq $figcap $caption -}}
+    {{ $caption = " " }}
+{{- end -}}
+
+{{- if $figcap -}}
     <figure>
-        {{- dict "Src" .Destination "Title" .Text "Caption" .Title "Linked" true "Resources" .Page.Resources | partial "plugin/image.html" -}}
+        {{- dict "Src" .Destination "Title" $figcap "Caption" $caption "Linked" true "Resources" .Page.Resources | partial "plugin/image.html" -}}
         <figcaption class="image-caption">
-            {{- .Title | safeHTML -}}
+            {{- $figcap | safeHTML -}}
         </figcaption>
     </figure>
 {{- else -}}
-    {{- dict "Src" .Destination "Title" .Text "Resources" .Page.Resources | partial "plugin/image.html" -}}
+    {{- dict "Src" .Destination "Title" (path.Base .Destination) "Resources" .Page.Resources | partial "plugin/image.html" -}}
 {{- end -}}


### PR DESCRIPTION
This address issues like #213 #238 #490 and others, which will enable `lightgallery` for most images in markdown document.

Enabled for image that has Text or/and Title:
```
![text](https://exapmle.com/image.png)
![](https://exapmle.com/image.png "title")
![text](https://exapmle.com/image.png "title")
```

Disable for image with neither Text not Title:
```
![](https://exapmle.com/image.png)
```

showcase: https://evilpan.com/2014/12/12/markdown-test/#%E5%9B%BE%E7%89%87