### PR TITLE
feat: Add Korean app translation for system

### DIFF
--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -1,0 +1,195 @@
+# Translations for English
+# https://gohugo.io/content-management/multilingual/#translation-of-strings
+
+# === baseof ==
+[backToTop]
+other = "맨 위로"
+
+[viewComments]
+other = "댓글 보기"
+# === baseof ==
+
+# === Post ===
+[posts]
+other = "글"
+# === Post ===
+
+# === Taxonomy ===
+[allSome]
+other = "모든 {{ .Some }}"
+
+[tag]
+other = "태그"
+
+[tags]
+other = "태그"
+
+[category]
+other = "카테고리"
+
+[categories]
+other = "카테고리"
+# === Taxonomy ===
+
+# === Pagination ===
+[more]
+other = "더 보기"
+# === Pagination ===
+
+# === partials/header.html ===
+[selectLanguage]
+other = "언어 변경"
+
+[switchTheme]
+other = "테마 변경"
+# === partials/header.html ===
+
+# === partials/footer.html ===
+[poweredBySome]
+other = "{{ .Hugo }}로 제작된 사이트 | 테마 - {{ .Theme }}"
+# === partials/footer.html ===
+
+# === partials/comment.html ===
+[valineLang]
+other = "ko"
+
+[valinePlaceholder]
+other = "댓글 입력..."
+
+[facebookLanguageCode]
+other = "ko-KR"
+# === partials/comment.html ===
+
+# === partials/assets.html ===
+[search]
+other = "검색"
+
+[searchPlaceholder]
+other = "제목이나 내용을 입력..."
+
+[clear]
+other = "지우기"
+
+[cancel]
+other = "취소"
+
+[noResultsFound]
+other = "검색 결과 없음"
+
+[lunrLanguageCode]
+other = "ko"
+
+[copyToClipboard]
+other = "복사하기"
+
+[cookieconsentMessage]
+other = "본 웹사이트는 웹 환경 개선을 위해 쿠키를 사용합니다."
+
+[cookieconsentDismiss]
+other = "알겠습니다"
+
+[cookieconsentLink]
+other = "더 보기"
+# === partials/assets.html ===
+
+# === partials/plugin/share.html ===
+[shareOn]
+other = "공유하기"
+# === partials/plugin/share.html ===
+
+# === posts/single.html ===
+[contents]
+other = "목차"
+
+[publishedOnDate]
+other = "작성: {{ .Date }}"
+
+[includedInCategories]
+other = "분류: {{ .Categories }}"
+
+[wordCount]
+one = "한 단어"
+other = "{{ .Count }} 단어"
+
+[readingTime]
+one = "읽는데 약 1분"
+other = "읽는데 약 {{ .Count }}분"
+
+[views]
+other = "조회"
+
+[author]
+other = "저자"
+
+[updatedOnDate]
+other = "수정: {{ .Date }}"
+
+[readMarkdown]
+other = "마크다운 읽기"
+
+[back]
+other = "뒤로"
+
+[home]
+other = "홈"
+
+[readMore]
+other = "더 읽기"
+# === posts/single.html ===
+
+# === 404.html ===
+[pageNotFound]
+other = "Page not found"
+
+[pageNotFoundText]
+other = "해당 페이지를 찾을 수 없습니다."
+# === 404.html ===
+
+# === shortcodes/admonition.html ===
+[note]
+other = "노트"
+
+[abstract]
+other = "요약"
+
+[info]
+other = "정보"
+
+[tip]
+other = "팁"
+
+[success]
+other = "성공"
+
+[question]
+other = "질문"
+
+[warning]
+other = "경고"
+
+[failure]
+other = "실패"
+
+[danger]
+other = "위험"
+
+[bug]
+other = "버그"
+
+[example]
+other = "예시"
+
+[quote]
+other = "인용"
+# === shortcodes/admonition.html ===
+
+# === shortcodes/version.html ===
+[new]
+other = "신규"
+
+[changed]
+other = "변경"
+
+[deleted]
+other = "삭제"
+# === shortcodes/version.html ===


### PR DESCRIPTION
* This text file were based on en.toml
* In Korean, generally there are no differences between singular and
  plural form. (not typo for tag-tags, category-categories)
* It seems Lunr, valine may not support korean, but I changed it into
  Korean to support immediately when they starts support.
* For the viewers who can understand Korean:
  대부분의 번역은 일반적인 웹페이지에서 사용하는 단어, 표현 위주로
  작성하였습니다.
  publish, update의 경우 작성, 수정으로 표현하였습니다.
  Shortcodes 중 abstract는 보통 논문에서는 '초록' 등의 표현을 사용하지만
  일반적인 웹페이지에서는 요약의 역할을 할 가능성이 높아 '요약'으로
  번역했습니다.

Signed-off-by: JaeSang Yoo <jsyoo5b@gmail.com>