### PR TITLE
fix bug: .params.author should be $params.author

### DIFF
--- a/layouts/partials/rss/item.html
+++ b/layouts/partials/rss/item.html
@@ -10,7 +10,7 @@
         {{- .Page.Date.Format "Mon, 02 Jan 2006 15:04:05 -0700"  -}}
     </pubDate>
     <author>
-        {{- .params.author | default (T "author") -}}
+        {{- $params.author | default (T "author") -}}
     </author>
     <guid>
         {{- .Page.Permalink -}}


### PR DESCRIPTION
This bug causes the author to not be displayed in the RSS file，look -> /index.xml

这个bug会导致在rss文件中无法显示作者