### PR TITLE
Added feature [Closes #621]

### DIFF
--- a/layouts/partials/single/footer.html
+++ b/layouts/partials/single/footer.html
@@ -62,11 +62,25 @@
     </div>
 
     <div class="post-nav">
-        {{- if .PrevInSection -}}
-            <a href="{{ .PrevInSection.RelPermalink }}" class="prev" rel="prev" title="{{ .PrevInSection.Title }}"><i class="fas fa-angle-left fa-fw"></i>{{ .PrevInSection.Title }}</a>
+        {{- if or ($params.next) ($params.prev) -}}
+            {{- with $next := $params.next -}}
+            {{- with $t := $.Site.GetPage $next -}}
+            <a href="{{ $t.RelPermalink }}" class="next" rel="next" title="{{ $t.Title }}">{{ $t.Title }}<i class="fas fa-angle-right fa-fw"></i></a>
+            {{- end -}}
+            {{- end -}}
+            {{- with $prev := $params.prev -}}
+            {{- with $t := $.Site.GetPage $prev -}}
+            <a href="{{ $t.RelPermalink }}" class="prev" rel="prev" title="{{ $t.Title }}"><i class="fas fa-angle-left fa-fw"></i>{{ $t.Title }}</a>
+            {{- end -}}
+            {{- end -}}
+        {{- else -}}
+            {{- if .PrevInSection -}}
+                <a href="{{ .PrevInSection.RelPermalink }}" class="prev" rel="prev" title="{{ .PrevInSection.Title }}"><i class="fas fa-angle-left fa-fw"></i>{{ .PrevInSection.Title }}</a>
+            {{- end -}}
+            {{ if .NextInSection }}
+                <a href="{{ .NextInSection.RelPermalink }}" class="next" rel="next" title="{{ .NextInSection.Title }}">{{ .NextInSection.Title }}<i class="fas fa-angle-right fa-fw"></i></a>
+            {{- end -}}
         {{- end -}}
-        {{ if .NextInSection }}
-            <a href="{{ .NextInSection.RelPermalink }}" class="next" rel="next" title="{{ .NextInSection.Title }}">{{ .NextInSection.Title }}<i class="fas fa-angle-right fa-fw"></i></a>
-        {{- end -}}
+        
     </div>
 </div>


### PR DESCRIPTION
Issue #621 

One can now add "prev" and "next" field to customize the footer previous and next post/page links.

Example of a markdown page's metadata with the new feature :


>title: "Second blog post #2"
date: 2019-12-01T21:57:40+08:00
lastmod: 2020-01-01T16:45:40+08:00
draft: false
author: "ParadiseLab"
description: "This article shows the new feature"

>*prev: "/posts/first_blogpost(.md)"*
>*next: "/posts/third_blogpost(.md)"*

