### PR TITLE
Update pt-br in i18n

### DIFF
--- a/i18n/pt-BR.toml
+++ b/i18n/pt-BR.toml
@@ -17,7 +17,7 @@ other = "Posts"
 
 # === Taxonomy ===
 [allSome]
-other = "Todos {{ .Some }}"
+other = "{{ .Some }}"
 
 [tag]
 other = "Tag"
@@ -47,7 +47,7 @@ other = "Trocar tema"
 
 # === partials/footer.html ===
 [poweredBySome]
-other = "Movido a {{ .Hugo }} | Tema - {{ .Theme }}"
+other = "Possibilitado por {{ .Hugo }} | Tema - {{ .Theme }}"
 # === partials/footer.html ===
 
 # === partials/comment.html ===
@@ -197,4 +197,3 @@ other = "ALTERADO"
 [deleted]
 other = "EXCLUÍDO"
 # === shortcodes/version.html ===
-


### PR DESCRIPTION
Signed-off-by: Junior Santos <claudio.dossantosjunior@yahoo.com.br>

A literal translation was performed for the term "powered by ...", the original translation does not make much sense for Portuguese. In addition, there is no neutral gender in Portuguese, making the term "Todos {}" to be used incorrectly as well. That way, instead of creating a male and a female gender, it's easier to remove it.