### PR TITLE
Fix code background color while using white mode

### DIFF
--- a/assets/css/_partial/_single/_code.scss
+++ b/assets/css/_partial/_single/_code.scss
@@ -30,10 +30,10 @@ pre {
 }
 
 code, pre, .highlight table, .highlight tr, .highlight td {
-  background: $code-background-color;
+  background: $code-background-color !important;
 
   [theme=dark] & {
-    background: $code-background-color-dark;
+    background: $code-background-color-dark !important;
   }
 }
 


### PR DESCRIPTION
Fix code background color while using the white mode with code type markdown
Hugo version 0.99.1 will generate CSS in code HTML like this
`style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4;"`

without override it, I will get something below
<img width="141" alt="image" src="https://user-images.githubusercontent.com/240147/170994655-98294c45-0d91-4fdb-89b9-37e5b691b010.png">


