### PR TITLE
adjust multi-languages icon for better understanding.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -39,29 +39,7 @@
                 {{- if .Site.Menus.main -}}
                     <span class="menu-item delimiter"></span>
                 {{- end -}}
-                {{- if .Site.IsMultiLingual -}}
-                    <a href="javascript:void(0);" class="menu-item language" title="{{ T "selectLanguage" }}">
-                        {{- .Language.LanguageName -}}
-                        <i class="fas fa-chevron-right fa-fw" aria-hidden="true"></i>
-                        <select class="language-select" id="language-select-desktop" onchange="location = this.value;">
-                            {{- if eq .Kind "404" -}}
-                                {{- /* https://github.com/dillonzq/LoveIt/issues/378 */ -}}
-                                {{- range .Sites -}}
-                                    {{- $link := printf "%v/404.html" .LanguagePrefix -}}
-                                    <option value="{{ $link }}"{{ if eq . $.Site }} selected{{ end }}>
-                                        {{- .Language.LanguageName -}}
-                                    </option>
-                                {{- end -}}
-                            {{- else -}}
-                                {{- range .AllTranslations -}}
-                                    <option value="{{ .RelPermalink }}"{{ if eq .Lang $.Lang }} selected{{ end }}>
-                                        {{- .Language.LanguageName -}}
-                                    </option>
-                                {{- end -}}
-                            {{- end -}}
-                        </select>
-                    </a>
-                {{- end -}}
+
                 {{- if .Site.Params.search.enable -}}
                     <span class="menu-item search" id="search-desktop">
                         <input type="text" placeholder="{{ .Site.Params.search.placeholder | default (T `searchPlaceholder`) }}" id="search-input-desktop">
@@ -79,6 +57,28 @@
                 <a href="javascript:void(0);" class="menu-item theme-switch" title="{{ T "switchTheme" }}">
                     <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
                 </a>
+                {{- if .Site.IsMultiLingual -}}
+                <a href="javascript:void(0);" class="menu-item language" title="{{ T "selectLanguage" }}">
+                    <i class="fa fa-globe" aria-hidden="true"></i>                      
+                    <select class="language-select" id="language-select-desktop" onchange="location = this.value;">
+                        {{- if eq .Kind "404" -}}
+                            {{- /* https://github.com/dillonzq/LoveIt/issues/378 */ -}}
+                            {{- range .Sites -}}
+                                {{- $link := printf "%v/404.html" .LanguagePrefix -}}
+                                <option value="{{ $link }}"{{ if eq . $.Site }} selected{{ end }}>
+                                    {{- .Language.LanguageName -}}
+                                </option>
+                            {{- end -}}
+                        {{- else -}}
+                            {{- range .AllTranslations -}}
+                                <option value="{{ .RelPermalink }}"{{ if eq .Lang $.Lang }} selected{{ end }}>
+                                    {{- .Language.LanguageName -}}
+                                </option>
+                            {{- end -}}
+                        {{- end -}}
+                    </select>
+                </a>
+            {{- end -}}
             </div>
         </div>
     </div>
@@ -150,9 +150,9 @@
                 <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
             </a>
             {{- if .Site.IsMultiLingual -}}
+            
                 <a href="javascript:void(0);" class="menu-item" title="{{ T "selectLanguage" }}">
-                    {{- .Language.LanguageName -}}
-                    <i class="fas fa-chevron-right fa-fw" aria-hidden="true"></i>
+                    <i class="fa fa-globe fa-fw" aria-hidden="true"></i>
                     <select class="language-select" onchange="location = this.value;">
                         {{- if eq .Kind "404" -}}
                             {{- /* https://github.com/dillonzq/LoveIt/issues/378 */ -}}


### PR DESCRIPTION
当前多语言的选择逻辑问题：

假设当博客的默认语言是“简体中文”， 而语言选择也是显示“简体中文”， 对非中文用户造成困扰，不知道该博客是否支持其他语言，以及在哪里选择多语言。


修改建议：不再显示当前语言名称，以地球图标代替``<i class="fa fa-globe" aria-hidden="true"></i>``，并将语言选择迁移至最后一个图标，符合用户的预期。

<img width="375" alt="Screen Shot 2022-07-08 at 23 57 10" src="https://user-images.githubusercontent.com/841310/178028090-7c3ee6d7-36a6-4054-b965-cfd85052d33f.png">


