### PR TITLE
remove unwanted padding for scaled down images

### DIFF
--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -212,6 +212,7 @@
     img {
       max-width: 100%;
       min-height: 1em;
+      height: auto;
     }
 
     figure {


### PR DESCRIPTION
Large images (`.single .content img`) will be scaled down according to the style `max-width: 100%`.

For example,  when a `1400*1400px` image is scaled to `700px`, the height is still `1400px` according to the element property of `height=1400` , which leaves unwanted huge padding on the top & bottom of the image.

This PR tries to add `height: auto;` to fix it.