### PR TITLE
fix scratch "this" name colliding with int symbols

### DIFF
--- a/layouts/partials/assets.html
+++ b/layouts/partials/assets.html
@@ -1,7 +1,7 @@
 {{- $params := .Scratch.Get "params" -}}
 {{- $cdn := .Scratch.Get "cdn" | default dict -}}
 {{- $fingerprint := .Scratch.Get "fingerprint" -}}
-{{- $config := (.Scratch.Get "this").config -}}
+{{- $config := (.Scratch.Get "assets").config -}}
 
 {{- /* Search */ -}}
 {{- if .Site.Params.search | and .Site.Params.search.enable -}}
@@ -71,7 +71,7 @@
 {{- end -}}
 
 {{- /* TypeIt */ -}}
-{{- with (.Scratch.Get "this").typeitMap -}}
+{{- with (.Scratch.Get "assets").typeitMap -}}
     {{- $typeit := $.Site.Params.typeit -}}
     {{- $source := $cdn.typeitJS | default "lib/typeit/index.umd.js" -}}
     {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" $.Scratch "Data" | partial "scratch/script.html" -}}
@@ -120,14 +120,14 @@
 {{- end -}}
 
 {{- /* mermaid */ -}}
-{{- if (.Scratch.Get "this").mermaid -}}
+{{- if (.Scratch.Get "assets").mermaid -}}
     {{- $source := $cdn.mermaidJS | default "lib/mermaid/mermaid.min.js" -}}
     {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
     {{- $_ := (resources.Get "lib/mermaid/mermaid.min.js.map").RelPermalink -}}
 {{- end -}}
 
 {{- /* ECharts */ -}}
-{{- if (.Scratch.Get "this").echarts -}}
+{{- if (.Scratch.Get "assets").echarts -}}
     {{- $source := $cdn.echartsJS | default "lib/echarts/echarts.min.js" -}}
     {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
     {{- $lightTheme := resources.Get "lib/echarts/theme/light.yml" | transform.Unmarshal -}}
@@ -136,7 +136,7 @@
 {{- end -}}
 
 {{- /* Mapbox GL */ -}}
-{{- if (.Scratch.Get "this").mapbox -}}
+{{- if (.Scratch.Get "assets").mapbox -}}
     {{- $source := $cdn.mapboxGLCSS | default "lib/mapbox-gl/mapbox-gl.min.css" -}}
     {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
     {{- $source := $cdn.mapboxGLJS | default "lib/mapbox-gl/mapbox-gl.min.js" -}}
@@ -146,7 +146,7 @@
 {{- end -}}
 
 {{- /* Music */ -}}
-{{- if (.Scratch.Get "this").music -}}
+{{- if (.Scratch.Get "assets").music -}}
     {{- /* APlayer */ -}}
     {{- $source := $cdn.aplayerCSS | default "lib/aplayer/APlayer.min.css" -}}
     {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
@@ -180,7 +180,7 @@
     {{- dict "Source" . "Fingerprint" $fingerprint | dict "Scratch" $.Scratch "Data" | partial "scratch/script.html" -}}
 {{- end -}}
 
-{{- with (.Scratch.Get "this").styleArr -}}
+{{- with (.Scratch.Get "assets").styleArr -}}
     {{- $content := delimit . "" -}}
     {{- $path := substr (md5 $content) 0 6 | printf "css/%v" -}}
     {{- $options := printf "%v.min.css" $path | dict "targetPath" -}}
@@ -193,15 +193,15 @@
 {{- /* Theme script */ -}}
 {{- dict "Source" "js/theme.js" "Minify" true "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
 
-{{- with (.Scratch.Get "this").scriptArr -}}
+{{- with (.Scratch.Get "assets").scriptArr -}}
     {{- delimit . "\n" | dict "Content" | dict "Scratch" $.Scratch "Data" | partial "scratch/script.html" -}}
 {{- end -}}
 
-{{- range (.Scratch.Get "this").style -}}
+{{- range (.Scratch.Get "assets").style -}}
     {{- partial "plugin/style.html" . -}}
 {{- end -}}
 
-{{- range (.Scratch.Get "this").script -}}
+{{- range (.Scratch.Get "assets").script -}}
     {{- partial "plugin/script.html" . -}}
 {{- end -}}
 

--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -149,4 +149,4 @@
     </div>
 {{- end -}}
 
-{{- dict "comment" $commentConfig | dict "config" | merge (.Scratch.Get "this") | .Scratch.Set "this" -}}
+{{- dict "comment" $commentConfig | dict "config" | merge (.Scratch.Get "assets") | .Scratch.Set "assets" -}}

--- a/layouts/partials/function/id.html
+++ b/layouts/partials/function/id.html
@@ -1,8 +1,8 @@
 {{- /* ID */ -}}
 {{- $count := (.Scratch.Get "this").count | default 1 -}}
 {{- $id := printf "id-%d" $count -}}
-{{- $count | add 1 | .Scratch.SetInMap "this" "count" -}}
+{{- $count | add 1 | .Scratch.SetInMap "assets" "count" -}}
 {{- with .Content -}}
-    {{- dict $id . | dict "data" | dict "config" | merge ($.Scratch.Get "this") | $.Scratch.Set "this" -}}
+    {{- dict $id . | dict "data" | dict "config" | merge ($.Scratch.Get "assets") | $.Scratch.Set "assets" -}}
 {{- end -}}
 {{- return $id -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,7 +13,7 @@
                     {{- if .typeit -}}
                         {{- $id := dict "Content" .name "Scratch" $.Scratch | partial "function/id.html" -}}
                         <span id="{{ $id }}" class="typeit"></span>
-                        {{- dict $id (slice $id) | dict "typeitMap" | merge ($.Scratch.Get "this") | $.Scratch.Set "this" -}}
+                        {{- dict $id (slice $id) | dict "typeitMap" | merge ($.Scratch.Get "assets") | $.Scratch.Set "assets" -}}
                     {{- else -}}
                         {{- .name -}}
                     {{- end -}}
@@ -100,7 +100,7 @@
                         {{- if .typeit -}}
                             {{- $id := dict "Content" .name "Scratch" $.Scratch | partial "function/id.html" -}}
                             <span id="{{ $id }}" class="typeit"></span>
-                            {{- dict $id (slice $id) | dict "typeitMap" | merge ($.Scratch.Get "this") | $.Scratch.Set "this" -}}
+                            {{- dict $id (slice $id) | dict "typeitMap" | merge ($.Scratch.Get "assets") | $.Scratch.Set "assets" -}}
                         {{- else -}}
                             {{- .name -}}
                         {{- end -}}

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -32,7 +32,7 @@
             {{- if $profile.typeit -}}
                 {{- $id := dict "Content" . "Scratch" $.Scratch | partial "function/id.html" -}}
                 <div id="{{ $id }}" class="typeit"></div>
-                {{- dict $id (slice $id) | dict "typeitMap" | merge ($.Scratch.Get "this") | $.Scratch.Set "this" -}}
+                {{- dict $id (slice $id) | dict "typeitMap" | merge ($.Scratch.Get "assets") | $.Scratch.Set "assets" -}}
             {{- else -}}
                 {{- . | safeHTML -}}
             {{- end -}}

--- a/layouts/partials/init.html
+++ b/layouts/partials/init.html
@@ -26,6 +26,6 @@
 {{- end -}}
 
 {{- .Scratch.Set "params" $params -}}
-{{- .Scratch.Set "this" dict -}}
+{{- .Scratch.Set "assets" dict -}}
 
 {{- partial "plugin/compatibility.html" . -}}

--- a/layouts/partials/scratch/script.html
+++ b/layouts/partials/scratch/script.html
@@ -1,4 +1,4 @@
-{{- $this := .Scratch.Get "this" -}}
+{{- $this := .Scratch.Get "assets" -}}
 {{- $script := $this.script | default slice -}}
 {{- $script = $script | append (slice .Data) -}}
-{{- .Scratch.SetInMap "this" "script" $script -}}
+{{- .Scratch.SetInMap "assets" "script" $script -}}

--- a/layouts/partials/scratch/style.html
+++ b/layouts/partials/scratch/style.html
@@ -1,4 +1,4 @@
-{{- $this := .Scratch.Get "this" -}}
+{{- $this := .Scratch.Get "assets" -}}
 {{- $style := $this.style | default slice -}}
 {{- $style = $style | append (slice .Data) -}}
-{{- .Scratch.SetInMap "this" "style" $style -}}
+{{- .Scratch.SetInMap "assets" "style" $style -}}

--- a/layouts/shortcodes/echarts.html
+++ b/layouts/shortcodes/echarts.html
@@ -3,5 +3,4 @@
 {{- $width := cond .IsNamedParams (.Get "width") (.Get 0) | default "100%" -}}
 {{- $height := cond .IsNamedParams (.Get "height") (.Get 1) | default "30rem" -}}
 <div class="echarts" id="{{ $id }}" style="width: {{ $width }}; height: {{ $height }};"></div>
-{{- end -}}
 {{- .Page.Scratch.SetInMap "assets" "echarts" true -}}

--- a/layouts/shortcodes/echarts.html
+++ b/layouts/shortcodes/echarts.html
@@ -3,4 +3,4 @@
 {{- $width := cond .IsNamedParams (.Get "width") (.Get 0) | default "100%" -}}
 {{- $height := cond .IsNamedParams (.Get "height") (.Get 1) | default "30rem" -}}
 <div class="echarts" id="{{ $id }}" style="width: {{ $width }}; height: {{ $height }};"></div>
-{{- .Page.Scratch.SetInMap "this" "echarts" true -}}
+{{- .Page.Scratch.SetInMap "assets" "echarts" true -}}

--- a/layouts/shortcodes/echarts.html
+++ b/layouts/shortcodes/echarts.html
@@ -3,4 +3,5 @@
 {{- $width := cond .IsNamedParams (.Get "width") (.Get 0) | default "100%" -}}
 {{- $height := cond .IsNamedParams (.Get "height") (.Get 1) | default "30rem" -}}
 <div class="echarts" id="{{ $id }}" style="width: {{ $width }}; height: {{ $height }};"></div>
+{{- end -}}
 {{- .Page.Scratch.SetInMap "assets" "echarts" true -}}

--- a/layouts/shortcodes/mapbox.html
+++ b/layouts/shortcodes/mapbox.html
@@ -30,4 +30,4 @@
 {{- $options := dict "lng" $lng "lat" $lat "zoom" $zoom "marked" $marked "lightStyle" $lightStyle "darkStyle" $darkStyle "geolocate" $geolocate "navigation" $navigation "scale" $scale "fullscreen" $fullscreen -}}
 {{- $id := dict "Content" $options "Scratch" .Page.Scratch | partial "function/id.html" -}}
 <div class="mapbox" id="{{ $id }}" style="width: {{ $width }}; height: {{ $height }};"></div>
-{{- .Page.Scratch.SetInMap "this" "mapbox" true -}}
+{{- .Page.Scratch.SetInMap "assets" "mapbox" true -}}

--- a/layouts/shortcodes/mermaid.html
+++ b/layouts/shortcodes/mermaid.html
@@ -1,3 +1,3 @@
 {{- $id := dict "Content" (trim .Inner "\n") "Scratch" .Page.Scratch | partial "function/id.html" -}}
 <div class="mermaid" id="{{ $id }}"></div>
-{{- .Page.Scratch.SetInMap "this" "mermaid" true -}}
+{{- .Page.Scratch.SetInMap "assets" "mermaid" true -}}

--- a/layouts/shortcodes/music.html
+++ b/layouts/shortcodes/music.html
@@ -47,4 +47,4 @@
 {{- else -}}
     <meting-js server="{{ .Get 0 }}" type="{{ .Get 1 }}" id="{{ .Get 2 }}" theme="{{ $theme }}"></meting-js>
 {{- end -}}
-{{- .Page.Scratch.SetInMap "this" "music" true -}}
+{{- .Page.Scratch.SetInMap "assets" "music" true -}}

--- a/layouts/shortcodes/script.html
+++ b/layouts/shortcodes/script.html
@@ -1,2 +1,2 @@
 {{- $scriptArr := (.Page.Scratch.Get "this").scriptArr | default slice -}}
-{{- $scriptArr | append (trim .Inner "\n") | .Page.Scratch.SetInMap "this" "scriptArr" -}}
+{{- $scriptArr | append (trim .Inner "\n") | .Page.Scratch.SetInMap "assets" "scriptArr" -}}

--- a/layouts/shortcodes/style.html
+++ b/layouts/shortcodes/style.html
@@ -5,4 +5,4 @@
 
 {{- $style := .Get 0 | printf "#%v{%v}" $id -}}
 {{- $styleArr := (.Page.Scratch.Get "this").styleArr | default slice -}}
-{{- $styleArr | append $style | .Page.Scratch.SetInMap "this" "styleArr" -}}
+{{- $styleArr | append $style | .Page.Scratch.SetInMap "assets" "styleArr" -}}

--- a/layouts/shortcodes/typeit.html
+++ b/layouts/shortcodes/typeit.html
@@ -27,7 +27,7 @@
 {{- $typeitMap := (.Page.Scratch.Get "this").typeitMap | default dict -}}
 {{- $group := index $typeitMap $key -}}
 {{- $group = $group | default slice | append $id -}}
-{{- dict $key $group | merge $typeitMap | .Page.Scratch.SetInMap "this" "typeitMap" -}}
+{{- dict $key $group | merge $typeitMap | .Page.Scratch.SetInMap "assets" "typeitMap" -}}
 
 {{- $attrs := printf `id="%v"` $id -}}
 {{- with $classList -}}


### PR DESCRIPTION
LoveIt uses a map called `this` in Page Scratch.

Although this works, it causes various heisenbugs in assets being randomly not loaded.

For example, the echarts library is included in a page of the main language, but not included in pages in different languages.

This is an insidious issue to troubleshoot, because "largely" the scratch work, and only occasionally it produces this unreliability.

This problem is also called out as an anti-pattern in [Go's guidelines](https://github.com/golang/go/wiki/CodeReviewComments#receiver-names), as [pointed out](https://stackoverflow.com/a/29028625).

This patch resolves this issue by simply renaming the scratch from `this` to `assets` throughout the code.