### PR TITLE
remove unwanted image padding and don't push well positioned anchors

### DIFF
--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -209,7 +209,7 @@
       }
     }
 
-    img {
+    img, svg {
       max-width: 100%;
       min-height: 1em;
       height: auto;

--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -212,6 +212,7 @@
     img {
       max-width: 100%;
       min-height: 1em;
+      height: auto;
     }
 
     figure {

--- a/layouts/partials/plugin/img.html
+++ b/layouts/partials/plugin/img.html
@@ -8,6 +8,8 @@
     {{- $height = $height | default .Height -}}
 {{- end -}}
 
+{{- $responsive := ne (or .SrcSmall .SrcLarge) nil -}}
+
 {{- $small := .SrcSmall | default $src -}}
 {{- with dict "Path" .SrcSmall "Resources" .Resources | partial "function/resource.html" -}}
     {{- $small = .RelPermalink -}}
@@ -21,24 +23,38 @@
 {{- $alt := .Alt | default $src -}}
 {{- $loading := resources.Get "svg/loading.svg" | minify -}}
 {{- if .Linked -}}
-    <a class="lightgallery" href="{{ $large | safeURL }}" title="{{ .Title | default $alt }}" data-thumbnail="{{ $small | safeURL }}"{{ with .Caption }} data-sub-html="<h2>{{ . }}</h2>{{ with $.Title }}<p>{{ . }}</p>{{ end }}"{{ end }}{{ with .Rel }} rel="{{ . }}"{{ end }}>
+    <a
+        class="lightgallery" 
+        href="{{ $large | safeURL }}" 
+        title="{{ .Title | default $alt }}" 
+        data-thumbnail="{{ $small | safeURL }}"
+        {{ with .Caption }} data-sub-html="<h2>{{ . }}</h2>{{ with $.Title }}<p>{{ . }}</p>{{ end }}"{{ end }}
+        {{ with .Rel }} rel="{{ . }}"{{ end }}>
         <img
-            class="lazyload{{ with .Class }} {{ . }}{{ end }}"
+            class="{{ if $responsive }}lazyload{{ end }}{{ with .Class }} {{ . }}{{ end }}"
+            {{ if $responsive }}
             src="{{ $loading.RelPermalink }}"
             data-src="{{ $src | safeURL }}"
             data-srcset="{{ $small | safeURL }}, {{ $src | safeURL }} 1.5x, {{ $large | safeURL }} 2x"
             data-sizes="auto"
+            {{ else }}
+            src="{{ $src | safeURL }}"
+            {{ end }}
             alt="{{ $alt }}"
             {{- with $width }} width="{{ . }}"{{ end }}
             {{- with $height }} height="{{ . }}"{{ end }} />
     </a>
 {{- else -}}
     <img
-        class="lazyload{{ with .Class }} {{ . }}{{ end }}"
+        class="{{ if $responsive }}lazyload{{ end }}{{ with .Class }} {{ . }}{{ end }}"
+        {{ if $responsive }}
         src="{{ $loading.RelPermalink }}"
         data-src="{{ $src | safeURL }}"
         data-srcset="{{ $small | safeURL }}, {{ $src | safeURL }} 1.5x, {{ $large | safeURL }} 2x"
         data-sizes="auto"
+        {{ else }}
+        src="{{ $src | safeURL }}"
+        {{ end }}
         alt="{{ $alt }}"
         title="{{ .Title | default $alt }}"
         {{- with $width }} width="{{ . }}"{{ end }}


### PR DESCRIPTION
The PR does two aspect of works:

1. remove unwanted padding for scaled down images

    Large images (`.single .content img`) will be scaled down according to the style `max-width: 100%`.

    For example,  when a `1400*1400px` image is scaled to `700px`, the height is still `1400px` according to the element property of `height=1400` , which leaves unwanted huge padding on the top & bottom of the image.

    The PR tries to add `height: auto;` to fix it.

1. don't push well positioned anchors 

    With the `height: auto;` style, the height of the image is not fixed after the execution of `lazysizes` library, which pushes well positioned anchors up or down right after the page is loaded & scrolled.

    > the problem still exists without the `height: auto;` style, for example, the image is from the internet and has no `width`/`height` set, the anchor is very likely to be pushed down after the image loaded.

    The problem is caused by `lazysizes` lib, but we don't need it in most cases while we writing code like `![](example.png)`.

    To avoid the problem, the PR choose to not activate `lazysizes` if we don't have multiple images for responsive usage.