### PR TITLE
add support of remark42 comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ I hope you will LoveIt ❤️!
 * **Commento** comment system supported by [Commento](https://commento.io/)
 * **utterances** comment system supported by [utterances](https://utteranc.es/)
 * **giscus** comment system supported by [giscus](https://giscus.app/)
+* **Remark42** comment system supported by [Remark42](https://remark42.com/)
 
 ### Extended Features
 

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -902,6 +902,17 @@ var Theme = /*#__PURE__*/function () {
 
           this.switchThemeEventSet.add(this._giscusOnSwitchTheme);
         }
+
+        if (this.config.comment.remark42) {
+          this._remark42OnSwitchTheme = function () {
+            if (_this11.isDark) {
+              window.REMARK42.changeTheme('dark');
+            } else {
+              window.REMARK42.changeTheme('light');
+            }
+          }
+          this.switchThemeEventSet.add(this._remark42OnSwitchTheme);
+        }
       }
     }
   }, {

--- a/config.toml
+++ b/config.toml
@@ -500,6 +500,10 @@
         lazyLoading = false
         lightTheme = "light"
         darkTheme = "dark"
+      [params.page.comment.remark42]
+        enable = false
+        host="https://demo.remark42.com"
+        siteId="remark"
     # Third-party library config
     # 第三方库配置
     [params.page.library]

--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -146,6 +146,28 @@
                 Please enable JavaScript to view the comments powered by <a href="https://giscus.app">Giscus</a>.
             </noscript>
         {{- end -}}
+
+        {{- /* Remark42 Comment System */ -}}
+        {{- $remark42 := $comment.remark42 | default dict -}}
+        {{- if $remark42.enable -}}
+
+        <script>
+            var remark_config = {
+                host: '{{ $remark42.host }}',
+                site_id: '{{ $remark42.siteId }}',
+                theme: document.body.getAttribute('theme') === 'dark' ? 'dark' : 'light',
+            }
+        </script>
+
+        <div id="remark42"></div>
+
+        {{- $source := printf "%v/web/embed.js" $remark42.host -}}
+        {{- dict "Source" $source "Defer" true | dict "Scratch" .Scratch "Data" | partial "scratch/script.html" -}}
+
+        <noscript>
+            Please enable JavaScript to view the comments powered by <a href="https://remark42.com">Remark42</a>.
+        </noscript>
+        {{- end -}}
     </div>
 {{- end -}}
 


### PR DESCRIPTION
Remark42 is self-hosted privacy-focused lightweight commenting engine.

It would be great to have its support in LogeIt theme.