### PR TITLE
feat: added supported for umami

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ I hope you will LoveIt ❤️!
 * **[Google Analytics](https://analytics.google.com/analytics)** supported
 * **[Fathom Analytics](https://usefathom.com/)** supported
 * **[Plausible Analytics](https://plausible.io/)** supported
+* **[Umami Analytics](https://umami.is/)** supported
 * **[Yandex Metrica](https://metrica.yandex.com/)** supported
 * Search engine **verification** supported (Google, Bind, Yandex and Baidu)
 * **CDN** for third-party libraries supported

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -61,6 +61,7 @@
 * 支持 **[Google Analytics](https://analytics.google.com/analytics)**
 * 支持 **[Fathom Analytics](https://usefathom.com/)**
 * 支持 **[Plausible Analytics](https://plausible.io/)**
+* 支持 **[Umami Analytics](https://umami.is/)**
 * 支持 **[Yandex Metrica](https://metrica.yandex.com/)**
 * 支持搜索引擎的**网站验证** (Google, Bind, Yandex and Baidu)
 * 支持所有第三方库的 **CDN**

--- a/config.toml
+++ b/config.toml
@@ -579,6 +579,10 @@
     # Plausible Analytics
     [params.analytics.plausible]
       dataDomain = ""
+    # Umami Analytics
+    [params.analytics.umami]
+      src = ""
+      dataWebsiteId = ""
     # Yandex Metrica
     [params.analytics.yandexMetrica]
       id = ""

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -664,6 +664,10 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
     # Plausible Analytics
     [params.analytics.plausible]
       dataDomain = ""
+    # Umami Analytics
+    [params.analytics.umami]
+      src = ""
+      dataWebsiteId = ""
     # Yandex Metrica
     [params.analytics.yandexMetrica]
       id = ""

--- a/exampleSite/content/about/index.en.md
+++ b/exampleSite/content/about/index.en.md
@@ -34,6 +34,7 @@ math:
 * :(fab fa-google fa-fw): **[Google Analytics](https://analytics.google.com/analytics)** supported
 * :(far fa-chart-bar fa-fw): **[Fathom Analytics](https://usefathom.com/)** supported
 * :(fas fa-chart-column fa-fw): **[Plausible Analytics](https://plausible.io/)** supported
+* :(fas fa-chart-pie fa-fw): **[Umami Analytics](https://umami.is/)** supported
 * :(fab fa-yandex-international fa-fw): **[Yandex Metrica](https://metrica.yandex.com/)** supported
 * :(fas fa-sitemap fa-fw): Search engine **verification** supported (Google, Bind, Yandex and Baidu)
 * :(fas fa-tachometer-alt fa-fw): **CDN** for third-party libraries supported

--- a/exampleSite/content/about/index.zh-cn.md
+++ b/exampleSite/content/about/index.zh-cn.md
@@ -34,6 +34,7 @@ math:
 * :(fab fa-google fa-fw): 支持 **[Google Analytics](https://analytics.google.com/analytics)**
 * :(far fa-chart-bar fa-fw): 支持 **[Fathom Analytics](https://usefathom.com/)**
 * :(fas fa-chart-column fa-fw): 支持 **[Plausible Analytics](https://plausible.io/)**
+* :(fas fa-chart-pie fa-fw): 支持 **[Umami Analytics](https://umami.is/)**
 * :(fab fa-yandex-international fa-fw): 支持 **[Yandex Metrica](https://metrica.yandex.com/)**
 * :(fas fa-sitemap fa-fw): 支持搜索引擎的**网站验证** (Google, Bind, Yandex and Baidu)
 * :(fas fa-tachometer-alt fa-fw): 支持所有第三方库的 **CDN**

--- a/exampleSite/content/posts/theme-documentation-basics/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.en.md
@@ -723,6 +723,7 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
     # Plausible Analytics
     [params.analytics.plausible]
       dataDomain = ""
+
     # Yandex Metrica
     [params.analytics.yandexMetrica]
       id = ""

--- a/exampleSite/content/posts/theme-documentation-basics/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.en.md
@@ -723,7 +723,10 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
     # Plausible Analytics
     [params.analytics.plausible]
       dataDomain = ""
-
+    # Umami Analytics
+    [params.analytics.umami]
+      src = ""
+      dataWebsiteId = ""
     # Yandex Metrica
     [params.analytics.yandexMetrica]
       id = ""

--- a/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
@@ -732,6 +732,7 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
     # Yandex Metrica
     [params.analytics.yandexMetrica]
       id = ""
+
   # {{< version 0.2.7 >}} Cookie 许可配置
   [params.cookieconsent]
     enable = true

--- a/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.zh-cn.md
@@ -725,10 +725,13 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
     # Plausible Analytics
     [params.analytics.plausible]
       dataDomain = ""
+    # Umami Analytics
+    [params.analytics.umami]
+      src = ""
+      dataWebsiteId = ""
     # Yandex Metrica
     [params.analytics.yandexMetrica]
       id = ""
-
   # {{< version 0.2.7 >}} Cookie 许可配置
   [params.cookieconsent]
     enable = true

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,4 +1,5 @@
 {{- $params := .Params | merge .Site.Params.page -}}
+{{- $siteAuthor := .Site.Params.author | default dict -}}
 
 <article class="single summary" itemscope itemtype="http://schema.org/Article">
     {{- /* Featured image */ -}}
@@ -24,8 +25,8 @@
 
     {{- /* Meta */ -}}
     <div class="post-meta">
-        {{- $author := $params.author | default .Site.Author.name | default (T "author") -}}
-        {{- $authorLink := $params.authorlink | default .Site.Author.link | default .Site.Home.RelPermalink -}}
+        {{- $author := $params.author | default $siteAuthor.name | default (T "author") -}}
+        {{- $authorLink := $params.authorlink | default $siteAuthor.link | default .Site.Home.RelPermalink -}}
         <span class="post-author">
             {{- $options := dict "Class" "author" "Destination" $authorLink "Title" "Author" "Rel" "author" "Icon" (dict "Class" "fas fa-user-circle fa-fw") "Content" $author -}}
             {{- partial "plugin/a.html" $options -}}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,0 +1,41 @@
+{{- define "title" -}}
+    {{- .Title }} - {{ T .Data.Singular | default .Data.Singular }} - {{ .Site.Title -}}
+{{- end -}}
+
+{{- define "content" -}}
+    <div class="page archive">
+        <h2 class="single-title animate__animated animate__pulse animate__faster">
+            {{- $taxonomy := .Data.Singular -}}
+            {{- if eq $taxonomy "category" -}}
+                <i class="far fa-folder-open fa-fw" aria-hidden="true"></i>&nbsp;{{ .Title }}
+            {{- else if eq $taxonomy "tag" -}}
+                <i class="fas fa-tag fa-fw" aria-hidden="true"></i>&nbsp;{{ .Title }}
+            {{- else -}}
+                {{- printf "%v - %v" (T $taxonomy | default $taxonomy) .Title -}}
+            {{- end -}}
+        </h2>
+
+        {{- if .Pages -}}
+            {{- $pages := .Pages.GroupByDate "2006" -}}
+            {{- with .Site.Params.list.paginate | default .Site.Params.paginate -}}
+                {{- $pages = $.Paginate $pages . -}}
+            {{- else -}}
+                {{- $pages = .Paginate $pages -}}
+            {{- end -}}
+            {{- range $pages.PageGroups -}}
+                <h3 class="group-title">{{ .Key }}</h3>
+                {{- range .Pages -}}
+                    <article class="archive-item">
+                        <a href="{{ .RelPermalink }}" class="archive-item-link">
+                            {{- .Title | emojify -}}
+                        </a>
+                        <span class="archive-item-date">
+                            {{- $.Site.Params.list.dateFormat | default "01-02" | .Date.Format -}}
+                        </span>
+                    </article>
+                {{- end -}}
+            {{- end -}}
+            {{- partial "paginator.html" . -}}
+        {{- end -}}
+    </div>
+{{- end -}}

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -1,3 +1,4 @@
+{{- $siteAuthor := .Site.Params.author | default dict -}}
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
         <title>
@@ -15,12 +16,12 @@
                 {{- . -}}
             </language>
         {{- end -}}
-        {{- with .Site.Author.email -}}
+        {{- with $siteAuthor.email -}}
             <managingEditor>
-                {{- . }}{{ with $.Site.Author.name }} ({{ . }}){{ end -}}
+                {{- . }}{{ with $siteAuthor.name }} ({{ . }}){{ end -}}
             </managingEditor>
             <webMaster>
-                {{- . }}{{ with $.Site.Author.name }} ({{ . }}){{ end -}}
+                {{- . }}{{ with $siteAuthor.name }} ({{ . }}){{ end -}}
             </webMaster>
         {{- end -}}
         {{- with .Site.Copyright -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,5 @@
 {{- if ne .Site.Params.footer.enable false -}}
+    {{- $siteAuthor := .Site.Params.author | default dict -}}
     <footer class="footer">
         <div class="footer-container">
             {{- /* Custom Content */ -}}
@@ -32,7 +33,7 @@
 
                 {{- /* Author */ -}}
                 {{- if ne .Site.Params.footer.author false -}}
-                    <span class="author" itemprop="copyrightHolder">&nbsp;<a href="{{ $.Site.Author.link | default .Site.Home.RelPermalink }}" target="_blank">{{ .Site.Author.name }}</a></span>
+                    <span class="author" itemprop="copyrightHolder">&nbsp;<a href="{{ $siteAuthor.link | default .Site.Home.RelPermalink }}" target="_blank">{{ $siteAuthor.name }}</a></span>
                 {{- end -}}
 
                 {{- /* License */ -}}

--- a/layouts/partials/head/seo.html
+++ b/layouts/partials/head/seo.html
@@ -1,4 +1,5 @@
 {{- $params := .Scratch.Get "params" -}}
+{{- $siteAuthor := .Site.Params.author | default dict -}}
 
 {{- with .Site.Params.verification.google -}}
     <meta name="google-site-verification" content="{{ . }}" />
@@ -26,7 +27,7 @@
         {{- with .Site.LanguageCode -}}
             "inLanguage": "{{ . }}",
         {{- end -}}
-        {{- with .Site.Author.name -}}
+        {{- with $siteAuthor.name -}}
             "author": {
                 "@type": "Person",
                 "name": {{ . | safeHTML }}
@@ -122,7 +123,7 @@
         {{- with .Site.Copyright -}}
             "license": {{ . | safeHTML }},
         {{- end -}}
-        {{- $publisher := .Params.author | default .Site.Author.name | default (T "author") | dict "name" -}}
+        {{- $publisher := .Params.author | default $siteAuthor.name | default (T "author") | dict "name" -}}
         {{- $publisher = $params.seo.publisher | default dict | merge $publisher -}}
         "publisher": {
             "@type": "Organization",
@@ -141,7 +142,7 @@
                 {{- end -}}
             {{- end -}}
         },
-        {{- with .Params.author | default .Site.Author.name | default (T "author") -}}
+        {{- with .Params.author | default $siteAuthor.name | default (T "author") -}}
             "author": {
                 "@type": "Person",
                 "name": {{ . | safeHTML }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -57,7 +57,7 @@
                 <a href="javascript:void(0);" class="menu-item theme-switch" title="{{ T "switchTheme" }}">
                     <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
                 </a>
-                {{- if .Site.IsMultiLingual -}}
+                {{- if gt (len .Site.Sites) 1 -}}
                 <a href="javascript:void(0);" class="menu-item language" title="{{ T "selectLanguage" }}">
                     <i class="fa fa-globe" aria-hidden="true"></i>                      
                     <select class="language-select" id="language-select-desktop" onchange="location = this.value;">
@@ -149,7 +149,7 @@
             <a href="javascript:void(0);" class="menu-item theme-switch" title="{{ T "switchTheme" }}">
                 <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
             </a>
-            {{- if .Site.IsMultiLingual -}}
+            {{- if gt (len .Site.Sites) 1 -}}
             
                 <a href="javascript:void(0);" class="menu-item" title="{{ T "selectLanguage" }}">
                     <i class="fa fa-globe fa-fw" aria-hidden="true"></i>

--- a/layouts/partials/plugin/analytics.html
+++ b/layouts/partials/plugin/analytics.html
@@ -25,6 +25,11 @@
         {{- dict "Source" "https://plausible.io/js/plausible.js" "Async" true "Defer" true "Attr" ($analytics.plausible.dataDomain | printf `data-domain="%v"`) | partial "plugin/script.html" -}}
     {{- end -}}
 
+    {{- /* Umami Analytics */ -}}
+    {{- with $analytics.umami.src -}}
+        {{- dict "Source" $analytics.umami.src "Async" true "Defer" true "Attr" ($analytics.umami.dataWebsiteId | printf `data-website-id="%v"`) | partial "plugin/script.html" -}}
+    {{- end -}}
+
     {{- /* Yandex Metrica */ -}}
     {{- with $analytics.yandexMetrica.id -}}
         <script type="text/javascript" >
@@ -40,4 +45,5 @@
         </script>
         <noscript><div><img src="https://mc.yandex.ru/watch/{{ . }}" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
     {{- end -}}
+
 {{- end -}}

--- a/layouts/partials/plugin/analytics.html
+++ b/layouts/partials/plugin/analytics.html
@@ -45,5 +45,4 @@
         </script>
         <noscript><div><img src="https://mc.yandex.ru/watch/{{ . }}" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
     {{- end -}}
-
 {{- end -}}

--- a/layouts/partials/rss/item.html
+++ b/layouts/partials/rss/item.html
@@ -1,4 +1,5 @@
-{{- $params := .Page.Params | merge .Site.Params.Page | merge (dict "author" .Site.Author.name) -}}
+{{- $siteAuthor := .Site.Params.author | default dict -}}
+{{- $params := .Page.Params | merge .Site.Params.Page | merge (dict "author" ($siteAuthor.name | default "")) -}}
 <item>
     <title>
         {{- .Page.Title -}}

--- a/layouts/posts/rss.xml
+++ b/layouts/posts/rss.xml
@@ -1,3 +1,4 @@
+{{- $siteAuthor := .Site.Params.author | default dict -}}
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
         <title>
@@ -15,12 +16,12 @@
                 {{- . -}}
             </language>
         {{- end -}}
-        {{- with .Site.Author.email -}}
+        {{- with $siteAuthor.email -}}
             <managingEditor>
-                {{- . }}{{ with $.Site.Author.name }} ({{ . }}){{ end -}}
+                {{- . }}{{ with $siteAuthor.name }} ({{ . }}){{ end -}}
             </managingEditor>
             <webMaster>
-                {{- . }}{{ with $.Site.Author.name }} ({{ . }}){{ end -}}
+                {{- . }}{{ with $siteAuthor.name }} ({{ . }}){{ end -}}
             </webMaster>
         {{- end -}}
         {{- with .Site.Copyright -}}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -2,6 +2,7 @@
 
 {{- define "content" -}}
     {{- $params := .Scratch.Get "params" -}}
+    {{- $siteAuthor := .Site.Params.author | default dict -}}
 
     {{- $toc := $params.toc -}}
     {{- if eq $toc true -}}
@@ -30,8 +31,8 @@
         {{- /* Meta */ -}}
         <div class="post-meta">
             <div class="post-meta-line">
-                {{- $author := $params.author | default .Site.Author.name | default (T "author") -}}
-                {{- $authorLink := $params.authorlink | default .Site.Author.link | default .Site.Home.RelPermalink -}}
+                {{- $author := $params.author | default $siteAuthor.name | default (T "author") -}}
+                {{- $authorLink := $params.authorlink | default $siteAuthor.link | default .Site.Home.RelPermalink -}}
                 <span class="post-author">
                     {{- $options := dict "Class" "author" "Destination" $authorLink "Title" "Author" "Rel" "author" "Icon" (dict "Class" "fas fa-user-circle fa-fw") "Content" $author -}}
                     {{- partial "plugin/a.html" $options -}}

--- a/layouts/shortcodes/version.html
+++ b/layouts/shortcodes/version.html
@@ -3,7 +3,7 @@
 {{- $type := .Get 1 | default "new" | lower -}}
 {{- $label := T $type -}}
 {{- $color := cond (eq $type "changed") "ff9101" "00b1ff" | cond (eq $type "deleted") "ff5252" -}}
-{{- $pathTemplate := cond .Site.IsMultiLingual (printf "svg/version/%%v-%%v.%v.svg" .Page.Language.Lang) "svg/version/%v-%v.svg" -}}
+{{- $pathTemplate := cond (gt (len .Site.Sites) 1) (printf "svg/version/%%v-%%v.%v.svg" .Page.Language.Lang) "svg/version/%v-%v.svg" -}}
 {{- $path := printf $pathTemplate $version $type -}}
 {{- $resource := resources.Get "svg/version.template.svg" -}}
 {{- $resource = $resource | resources.ExecuteAsTemplate $path (dict "version" $version "label" $label "color" $color) | minify -}}

--- a/layouts/taxonomy/rss.xml
+++ b/layouts/taxonomy/rss.xml
@@ -1,3 +1,4 @@
+{{- $siteAuthor := .Site.Params.author | default dict -}}
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
         <title>
@@ -15,12 +16,12 @@
                 {{- . -}}
             </language>
         {{- end -}}
-        {{- with .Site.Author.email -}}
+        {{- with $siteAuthor.email -}}
             <managingEditor>
-                {{- . }}{{ with $.Site.Author.name }} ({{ . }}){{ end -}}
+                {{- . }}{{ with $siteAuthor.name }} ({{ . }}){{ end -}}
             </managingEditor>
             <webMaster>
-                {{- . }}{{ with $.Site.Author.name }} ({{ . }}){{ end -}}
+                {{- . }}{{ with $siteAuthor.name }} ({{ . }}){{ end -}}
             </webMaster>
         {{- end -}}
         {{- with .Site.Copyright -}}


### PR DESCRIPTION
This PR should allow users to use their self-hosted instances of [umami](https://umami.is/) analytics in their hugo websites.