### PR TITLE
Add height: auto to fix issue #777

### DIFF
--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -212,6 +212,7 @@
     img {
       max-width: 100%;
       min-height: 1em;
+      height: auto;
     }
 
     figure {


### PR DESCRIPTION
This commit adds height: auto to the img selector to fix issue #777.