### PR TITLE
Resolve markdown image referrer errors

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -7,7 +7,7 @@
 
 <meta name="application-name" content="{{ .Site.Params.app.title | default .Site.Title }}">
 <meta name="apple-mobile-web-app-title" content="{{ .Site.Params.app.title | default .Site.Title }}">
-
+<meta name="referrer" content="no-referrer" />
 {{- with .Site.Params.app.themeColor -}}
     <meta name="theme-color" content="{{ . }}">
 {{- end -}}


### PR DESCRIPTION
add <meta name="referrer" content="no-referrer" /> to meta to resolve markdown image referrer errors