### PR TITLE
fix: valine.js override pulse animate on special page title

### DIFF
--- a/assets/lib/valine/valine.scss
+++ b/assets/lib/valine/valine.scss
@@ -67,3 +67,22 @@ $code-background-color-dark: #272C34 !default;
     vertical-align: text-bottom;
   }
 }
+
+// fix valine.js inside css will be override pulse animate for page title
+@keyframes pulse {
+    0% {
+        -webkit-transform: scaleX(1);
+        transform: scaleX(1)
+    }
+
+    50% {
+        -webkit-transform: scale3d(1.05, 1.05, 1.05);
+        transform: scale3d(1.05, 1.05, 1.05)
+    }
+
+    to {
+        -webkit-transform: scaleX(1);
+        transform: scaleX(1)
+    }
+}
+


### PR DESCRIPTION
处理自定义页面并且加载valine评论后的标题动画闪烁的错误显示问题