### PR TITLE
fix analytics

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -57,9 +57,9 @@
                 <a href="javascript:void(0);" class="menu-item theme-switch" title="{{ T "switchTheme" }}">
                     <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
                 </a>
-                {{- if .Site.IsMultiLingual -}}
+                {{- if hugo.IsMultilingual -}}
                 <a href="javascript:void(0);" class="menu-item language" title="{{ T "selectLanguage" }}">
-                    <i class="fa fa-globe" aria-hidden="true"></i>                      
+                    <i class="fa fa-globe" aria-hidden="true"></i>
                     <select class="language-select" id="language-select-desktop" onchange="location = this.value;">
                         {{- if eq .Kind "404" -}}
                             {{- /* https://github.com/dillonzq/LoveIt/issues/378 */ -}}
@@ -149,8 +149,8 @@
             <a href="javascript:void(0);" class="menu-item theme-switch" title="{{ T "switchTheme" }}">
                 <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
             </a>
-            {{- if .Site.IsMultiLingual -}}
-            
+            {{- if hugo.IsMultilingual -}}
+
                 <a href="javascript:void(0);" class="menu-item" title="{{ T "selectLanguage" }}">
                     <i class="fa fa-globe fa-fw" aria-hidden="true"></i>
                     <select class="language-select" onchange="location = this.value;">

--- a/layouts/partials/plugin/analytics.html
+++ b/layouts/partials/plugin/analytics.html
@@ -1,5 +1,4 @@
-{{- $analytics := .Scratch.Get "analytics" | default dict -}}
-
+{{- $analytics := .Site.Param "analytics" | default dict -}}
 {{- if $analytics.enable -}}
     {{- /* Google Analytics */ -}}
     {{- with $analytics.google.id -}}

--- a/layouts/shortcodes/version.html
+++ b/layouts/shortcodes/version.html
@@ -3,7 +3,7 @@
 {{- $type := .Get 1 | default "new" | lower -}}
 {{- $label := T $type -}}
 {{- $color := cond (eq $type "changed") "ff9101" "00b1ff" | cond (eq $type "deleted") "ff5252" -}}
-{{- $pathTemplate := cond .Site.IsMultiLingual (printf "svg/version/%%v-%%v.%v.svg" .Page.Language.Lang) "svg/version/%v-%v.svg" -}}
+{{- $pathTemplate := cond hugo.IsMultilingual (printf "svg/version/%%v-%%v.%v.svg" .Page.Language.Lang) "svg/version/%v-%v.svg" -}}
 {{- $path := printf $pathTemplate $version $type -}}
 {{- $resource := resources.Get "svg/version.template.svg" -}}
 {{- $resource = $resource | resources.ExecuteAsTemplate $path (dict "version" $version "label" $label "color" $color) | minify -}}


### PR DESCRIPTION
I noticed my Plausible Analytics code wasn't showing up. After investigating, I found that 

```
{{- $analytics := .Scratch.Get "analytics" | default dict -}}
```

was returning `[]` instead of the actual values found inside `.Site.Params.analytics`


This change makes the analytics snippet appear on my site.
