### PR TITLE
(bug) fig img css fix and (feat) profile avatar link

### DIFF
--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -230,8 +230,8 @@
 
       img {
         display: block;
-        width: 100%;
-        height: auto;
+        width: auto;
+        height: 100%;
         margin: 0 auto;
         overflow: hidden;
       }

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -262,6 +262,8 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
       # URL of avatar shown in home page
       # 主页显示头像的 URL
       avatarURL = "/images/avatar.png"
+      # avatar link - where to redirect upon clicking the avatar
+      avatarLink = "/about/"
       # title shown in home page (HTML format is supported)
       # 主页显示的网站标题 (支持 HTML 格式)
       title = ""

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -7,12 +7,9 @@
     {{- if $avatar -}}
         <div class="home-avatar">
             {{- $menus := $.Site.Menus.main | default slice -}}
-            {{- with index $menus 0 -}}
-                {{- $url := .URL | relLangURL -}}
-                {{- with .Page -}}
-                    {{- $url = .RelPermalink -}}
-                {{- end -}}
-                <a href="{{ $url }}"{{ with .Title | default .Name }} title="{{ . }}"{{ end }}{{ if (urls.Parse $url).Host }} rel="noopener noreffer" target="_blank"{{ end }}>
+            {{- with $profile.avatarLink -}}
+                {{- $url := . | relLangURL -}}
+                <a href="{{ $url }}">
                     {{- dict "Src" $avatar | partial "plugin/img.html" -}}
                 </a>
             {{- else -}}


### PR DESCRIPTION
This PR is made up of 2 parts
## 1. (Bug fix) for images within figure
Before: Images within figure tag were stretched to fill the screen. This resulted in an unpleasant stretching of imgs in some cases (especially phone ss'd imgs)
![Before](https://github.com/dillonzq/LoveIt/assets/23740867/594802ca-e9fe-4b44-a185-927c41a898aa)
After: Images are properly scaled to match their heights
![After](https://github.com/dillonzq/LoveIt/assets/23740867/6ccd8aad-6021-48d0-ab0e-8488531ef924)
## 2. (feature) Profile avatar link
Added a new config param `params.home.profile.avatarLink`. Used this tag to redirect to upon clicking avatarImg. Link for ex: about page or github profile link :)