### PR TITLE
[FIX] Deprecated alert on apple arm

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -57,7 +57,7 @@
                 <a href="javascript:void(0);" class="menu-item theme-switch" title="{{ T "switchTheme" }}">
                     <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
                 </a>
-                {{- if .Site.IsMultiLingual -}}
+                {{- if .Site.Params.IsMultiLingual -}}
                 <a href="javascript:void(0);" class="menu-item language" title="{{ T "selectLanguage" }}">
                     <i class="fa fa-globe" aria-hidden="true"></i>                      
                     <select class="language-select" id="language-select-desktop" onchange="location = this.value;">
@@ -149,7 +149,7 @@
             <a href="javascript:void(0);" class="menu-item theme-switch" title="{{ T "switchTheme" }}">
                 <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
             </a>
-            {{- if .Site.IsMultiLingual -}}
+            {{- if .Site.Params.IsMultiLingual -}}
             
                 <a href="javascript:void(0);" class="menu-item" title="{{ T "selectLanguage" }}">
                     <i class="fa fa-globe fa-fw" aria-hidden="true"></i>

--- a/layouts/partials/init.html
+++ b/layouts/partials/init.html
@@ -22,7 +22,8 @@
         {{- .Scratch.Set "comment" dict -}}
     {{- end -}}
 {{- else if eq .Site .Sites.First -}}
-    {{- warnf "\n\nCurrent environment is \"development\". The \"comment system\", \"CDN\" and \"fingerprint\" will be disabled.\n当前运行环境是 \"development\". \"评论系统\", \"CDN\" 和 \"fingerprint\" 不会启用.\n" -}}
+    {{- warnf "Current environment is \"development\". The \"comment system\", \"CDN\" and \"fingerprint\" will be disabled." -}}
+    {{- warnf "当前运行环境是 \"development\". \"评论系统\", \"CDN\" 和 \"fingerprint\" 不会启用." -}}
 {{- end -}}
 
 {{- .Scratch.Set "params" $params -}}


### PR DESCRIPTION
## Description

A deprecated alert is prompting when Hugo server is called.
The error points to

 ```html
 .Site.IsMultiLingual
 ```

 And ask for replacement to 
 
```
 .Site.Params.IsMultiLingual
```

A local correction to the alert, following whats asked in the log and researching for the new Params on internet, proved enough to solve the problem and make the server functional again

The problem happens only AFIK in Apple ARM machines, as it's the only people complaining about the problem.

Didn't tried to reproduce the error in another machines 

Hugo installed via Brew install 
Theme installed via git submodule as Hugo doc 

PS 

A warn started to break for no reason, and after I break it into two lines the problem was solved. 

```bash
WARN  Current environment is "development". The "comment system", "CDN" and "fingerprint" will be disabled.
WARN  当前运行环境是 "development". "评论系统", "CDN" 和 "fingerprint" 不会启用.
```

Not part of the deprecated alert, but to run the project I need to correct it first.

PS2

Another deprecation alert was happening, but as it not a impediment I let it stays for further evaluation 

<img width="992" alt="image" src="https://github.com/user-attachments/assets/14a132bb-9b49-4e95-afc3-2623b74687c6">





