### PR TITLE
fix: replace .Site.IsMultiLingual with hugo.IsMultilingual

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -57,7 +57,7 @@
                 <a href="javascript:void(0);" class="menu-item theme-switch" title="{{ T "switchTheme" }}">
                     <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
                 </a>
-                {{- if .Site.IsMultiLingual -}}
+                {{- if hugo.IsMultilingual -}}
                 <a href="javascript:void(0);" class="menu-item language" title="{{ T "selectLanguage" }}">
                     <i class="fa fa-globe" aria-hidden="true"></i>                      
                     <select class="language-select" id="language-select-desktop" onchange="location = this.value;">
@@ -149,7 +149,7 @@
             <a href="javascript:void(0);" class="menu-item theme-switch" title="{{ T "switchTheme" }}">
                 <i class="fas fa-adjust fa-fw" aria-hidden="true"></i>
             </a>
-            {{- if .Site.IsMultiLingual -}}
+            {{- if hugo.IsMultilingual -}}
             
                 <a href="javascript:void(0);" class="menu-item" title="{{ T "selectLanguage" }}">
                     <i class="fa fa-globe fa-fw" aria-hidden="true"></i>

--- a/layouts/shortcodes/version.html
+++ b/layouts/shortcodes/version.html
@@ -3,7 +3,7 @@
 {{- $type := .Get 1 | default "new" | lower -}}
 {{- $label := T $type -}}
 {{- $color := cond (eq $type "changed") "ff9101" "00b1ff" | cond (eq $type "deleted") "ff5252" -}}
-{{- $pathTemplate := cond .Site.IsMultiLingual (printf "svg/version/%%v-%%v.%v.svg" .Page.Language.Lang) "svg/version/%v-%v.svg" -}}
+{{- $pathTemplate := cond hugo.IsMultilingual (printf "svg/version/%%v-%%v.%v.svg" .Page.Language.Lang) "svg/version/%v-%v.svg" -}}
 {{- $path := printf $pathTemplate $version $type -}}
 {{- $resource := resources.Get "svg/version.template.svg" -}}
 {{- $resource = $resource | resources.ExecuteAsTemplate $path (dict "version" $version "label" $label "color" $color) | minify -}}


### PR DESCRIPTION
The change from `.Site.IsMultiLingual` to `hugo.IsMultilingual` was made to ensure compatibility with newer versions of Hugo. The method `.Site.IsMultiLingual` was deprecated starting from Hugo` v0.124.0,` and it was officially removed in v0.140.0. As part of Hugo's ongoing effort to improve the platform, it is essential to update code to use the recommended alternatives before older methods are fully phased out.

hugo.IsMultilingual is the new, recommended approach to check if the site is multilingual, aligning with Hugo's updated API. This change helps future-proof the site and ensures it continues to function correctly with the latest Hugo versions. By adopting this change, we also avoid potential build issues when upgrading Hugo in the future.