### PR TITLE
docs: RenderString error for escape shortcodes in doc

### DIFF
--- a/exampleSite/content/posts/theme-documentation-content/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-content/index.en.md
@@ -278,13 +278,13 @@ which helps you write raw mathematical formula content.
 Example `raw` input:
 
 ```markdown
-Inline Formula: {{</* raw */>}}\(\mathbf{E}=\sum_{i} \mathbf{E}_{i}=\mathbf{E}_{1}+\mathbf{E}_{2}+\mathbf{E}_{3}+\cdots\){{</* /raw */>}}
+Inline Formula: {?{}{< raw >}}\(\mathbf{E}=\sum_{i} \mathbf{E}_{i}=\mathbf{E}_{1}+\mathbf{E}_{2}+\mathbf{E}_{3}+\cdots\){?{}{< /raw >}}
 
 Block Formula:
 
-{{</* raw */>}}
+{?{}{< raw >}}
 \[ a=b+c \\ d+e=f \]
-{{</* /raw */>}}
+{?{}{< /raw >}}
 ```
 
 The rendered output looks like this:
@@ -293,7 +293,7 @@ Inline Formula: {{< raw >}}\(\mathbf{E}=\sum_{i} \mathbf{E}_{i}=\mathbf{E}_{1}+\
 
 Block Formula:
 
-{{< raw>}}
+{{< raw >}}
 \[ a=b+c \\ d+e=f \]
 {{< /raw >}}
 {{< /admonition >}}
@@ -307,7 +307,7 @@ The default inline delimiters are:
 
 For example:
 
-```tex
+```markdown
 $c = \pm\sqrt{a^2 + b^2}$ and \\(f(x)=\int_{-\infty}^{\infty} \hat{f}(\xi) e^{2 \pi i \xi x} d \xi\\)
 ```
 
@@ -329,7 +329,7 @@ The default block delimiters are:
 
 For example:
 
-```tex
+```markdown
 $$ c = \pm\sqrt{a^2 + b^2} $$
 
 \\[ f(x)=\int_{-\infty}^{\infty} \hat{f}(\xi) e^{2 \pi i \xi x} d \xi \\]

--- a/exampleSite/content/posts/theme-documentation-content/index.zh-cn.md
+++ b/exampleSite/content/posts/theme-documentation-content/index.zh-cn.md
@@ -276,13 +276,13 @@ resources:
 一个 `raw` 示例:
 
 ```markdown
-行内公式: {{</* raw */>}}\(\mathbf{E}=\sum_{i} \mathbf{E}_{i}=\mathbf{E}_{1}+\mathbf{E}_{2}+\mathbf{E}_{3}+\cdots\){{</* /raw */>}}
+行内公式: {?{}{< raw >}}\(\mathbf{E}=\sum_{i} \mathbf{E}_{i}=\mathbf{E}_{1}+\mathbf{E}_{2}+\mathbf{E}_{3}+\cdots\){?{}{< /raw >}}
 
 公式块:
 
-{{</* raw */>}}
+{?{}{< raw >}}
 \[ a=b+c \\ d+e=f \]
-{{</* /raw */>}}
+{?{}{< /raw >}}
 ```
 
 呈现的输出效果如下:
@@ -305,7 +305,7 @@ resources:
 
 例如:
 
-```tex
+```markdown
 $c = \pm\sqrt{a^2 + b^2}$ 和 \\(f(x)=\int_{-\infty}^{\infty} \hat{f}(\xi) e^{2 \pi i \xi x} d \xi\\)
 ```
 
@@ -327,7 +327,7 @@ $c = \pm\sqrt{a^2 + b^2}$ 和 \\(f(x)=\int_{-\infty}^{\infty} \hat{f}(\xi) e^{2 
 
 例如:
 
-```tex
+```markdown
 $$ c = \pm\sqrt{a^2 + b^2} $$
 
 \\[ f(x)=\int_{-\infty}^{\infty} \hat{f}(\xi) e^{2 \pi i \xi x} d \xi \\]

--- a/exampleSite/content/posts/theme-documentation-extended-shortcodes/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-extended-shortcodes/index.en.md
@@ -374,11 +374,6 @@ Block Formula:
 \[ a=b+c \\ d+e=f \]
 {{< /raw >}}
 
-{{< script >}}
-console.log('Hello LoveIt!');
-{{< /script >}}
-
-This renders as {{< person "https://dillonzq.com/" Dillon "author of the LoveIt theme" >}}.
 Raw content using Markdown syntax: {{< raw >}}**Hello**{{< /raw >}}
 
 ## 13 person


### PR DESCRIPTION
See https://discourse.gohugo.io/t/page-renderstring-throws-error-when-rendering-an-escaped-shortcode-call/40292 and https://github.com/gohugoio/hugo/issues/10058