### PR TITLE
Fix code title always is Bash (language-bash)

### DIFF
--- a/layouts/partials/plugin/code-block.html
+++ b/layouts/partials/plugin/code-block.html
@@ -12,7 +12,7 @@
 {{- $options = dict "noClasses" false "lineNos" false | merge $options -}}
 {{- $result := transform.Highlight $content $lang $options -}}
 <div class="code-block{{ if $lineNos }} code-line-numbers{{ end }}{{ if le $lines $maxShownLines }} open{{ end }}" style="counter-reset: code-block {{ sub $lineNoStart 1 }}">
-    <div class="code-header language-bash">
+    <div class="code-header language-{{ $lang }}">
         <span class="code-title"><i class="arrow fas fa-chevron-right fa-fw" aria-hidden="true"></i></span>
         <span class="ellipses"><i class="fas fa-ellipsis-h fa-fw" aria-hidden="true"></i></span>
         {{ if $copy }}<span class="copy" title="{{ T "copyToClipboard" }}"><i class="far fa-copy fa-fw" aria-hidden="true"></i></span>{{ end }}


### PR DESCRIPTION
Fix bug: code title always is Bash in code blocks.