### PR TITLE
Update es.toml

### DIFF
--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -9,7 +9,7 @@ other = "Volver arriba"
 [viewComments]
 other = "Ver comentarios"
 # === baseof ==
-
+https://github.com/dillonzq/LoveIt/blob/master/i18n/es.toml
 # === Post ===
 [posts]
 other = "Artículos"
@@ -17,7 +17,7 @@ other = "Artículos"
 
 # === Taxonomy ===
 [allSome]
-other = "Todos los {{ .Some }}"
+other = "Todas las {{ .Some }}"
 
 [tag]
 other = "Etiqueta"


### PR DESCRIPTION
Change made because in Spanish it is incorrect to say "Todos los categorias" or "Todos los etiquetas."

The correct way to say "Todas las etiquetas" and "Todas las categorias" is to say "Todas las etiquetas" and "Todas las categorias."