### PR TITLE
add Bluesky as social

### DIFF
--- a/assets/data/cdn/cdnjs.yml
+++ b/assets/data/cdn/cdnjs.yml
@@ -1,7 +1,7 @@
 prefix:
   libFiles: https://cdnjs.cloudflare.com/ajax/libs/
   # simple-icons@14.1.0 https://github.com/simple-icons/simple-icons
-  simpleIcons: https://cdnjs.cloudflare.com/ajax/libs/simple-icons/14.1.0/
+  simpleIcons: https://cdnjs.cloudflare.com/ajax/libs/simple-icons/15.12.0/
 libFiles:
   # fontawesome-free@6.7.2 https://fontawesome.com/
   fontawesomeFreeCSS: font-awesome/6.7.2/css/all.min.css

--- a/assets/data/social.yml
+++ b/assets/data/social.yml
@@ -620,6 +620,14 @@ threads:
   Icon:
     Class: fab fa-threads fa-fw
 
+# 079: BlueSky
+bluesky:
+  Weight: 79
+  Title: BlueSky
+  Prefix: https://bsky.app/profile/
+  Icon:
+    Simpleicons: bluesky
+
 # Phone
 phone:
   Weight: 98

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -366,6 +366,7 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
     Codeberg = ""
     HuggingFace = ""
     Threads = ""
+    Bluesky = ""
     Email = ""
     RSS = ""
 


### PR DESCRIPTION
This pull request updates the CDN reference for Simple Icons, adds BlueSky as a supported social profile, and ensures configuration compatibility for BlueSky in the example site. These changes improve icon support and expand the list of available social platforms.

**CDN and icon updates:**

* Updated the `simpleIcons` CDN URL in `assets/data/cdn/cdnjs.yml` to use version 15.12.0, ensuring access to the latest icon set.

**Social profile additions:**

* Added BlueSky as a supported social profile in `assets/data/social.yml`, including its title, prefix, and icon reference.

**Configuration compatibility:**

* Added a `Bluesky` entry to the social configuration section in `exampleSite/hugo.toml` to support the new profile.