### PR TITLE
fix RSS author

### DIFF
--- a/layouts/partials/rss/item.html
+++ b/layouts/partials/rss/item.html
@@ -10,14 +10,10 @@
         {{- .Page.Date.Format "Mon, 02 Jan 2006 15:04:05 -0700"  -}}
     </pubDate>
     <author>
-      {{- with $params.author -}}
-        {{- with $params.author.email -}}
-          {{- $params.author.email }}{{ with $params.author.name }} ({{ . }}){{ end -}}
-        {{- else -}}
-          {{- $params.author.name -}}
-        {{ end -}}
+      {{- with .Site.Params.Author.email -}}
+        {{- . }}{{ with $.Site.Params.Author.name }} ({{ . }}){{ end -}}
       {{- else -}}
-        {{- default (T "author") -}}
+        {{- with $.Site.Params.Author.name }}{{ . }}{{ end -}}
       {{- end -}}
     </author>
     <guid>

--- a/layouts/partials/rss/item.html
+++ b/layouts/partials/rss/item.html
@@ -1,4 +1,4 @@
-{{- $params := .Page.Params | merge .Site.Params.Page | merge (dict "author" .Site.Params.Author.name) -}}
+{{- $params := .Page.Params | merge .Site.Params.Page | merge (dict "author" .Site.Params.Author) -}}
 <item>
     <title>
         {{- .Page.Title -}}
@@ -10,7 +10,11 @@
         {{- .Page.Date.Format "Mon, 02 Jan 2006 15:04:05 -0700"  -}}
     </pubDate>
     <author>
+      {{- with $params.author.email -}}
+        {{- . }}{{ with $params.author.name }} ({{ . }}){{ end -}}
+      {{- else -}}
         {{- $params.author | default (T "author") -}}
+      {{- end -}}
     </author>
     <guid>
         {{- .Page.Permalink -}}

--- a/layouts/partials/rss/item.html
+++ b/layouts/partials/rss/item.html
@@ -10,10 +10,14 @@
         {{- .Page.Date.Format "Mon, 02 Jan 2006 15:04:05 -0700"  -}}
     </pubDate>
     <author>
-      {{- with $params.author.email -}}
-        {{- . }}{{ with $params.author.name }} ({{ . }}){{ end -}}
+      {{- with $params.author -}}
+        {{- with $params.author.email -}}
+          {{- $params.author.email }}{{ with $params.author.name }} ({{ . }}){{ end -}}
+        {{- else -}}
+          {{- $params.author.name -}}
+        {{ end -}}
       {{- else -}}
-        {{- $params.author | default (T "author") -}}
+        {{- default (T "author") -}}
       {{- end -}}
     </author>
     <guid>


### PR DESCRIPTION
This pull request updates the RSS item partial to improve how author information is handled and displayed. The main changes focus on ensuring both the author's name and email are correctly included in the RSS feed when available.

You can check it here: https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fhugoloveit.com%2Findex.xml

Improvements to author information handling:

* Changed `$params.author` to use the full `Author` object from `.Site.Params.Author` instead of just the name, allowing access to both name and email.
* Updated the `<author>` tag logic to display the author's email followed by their name in parentheses if the email is present, or just the name if not.