### PR TITLE
Feat: Add support for an extra description field

### DIFF
--- a/assets/css/_page/_home.scss
+++ b/assets/css/_page/_home.scss
@@ -39,6 +39,18 @@
       padding: .5rem;
     }
 
+    .home-extra {
+      font-size: 0.85rem;
+      font-weight: 350;
+      font-style: italic;
+      margin: 0;
+      padding-bottom: .5rem;
+    }
+
+    .home-extra.no-italic {
+      font-style: normal;
+    }
+
     .links {
       padding: .5rem;
       font-size: 1.5rem;

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -272,6 +272,10 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
       # whether to use typeit animation for subtitle
       # 是否为副标题显示打字机动画
       typeit = true
+      # you can add extra information after the subtitle, such as citations or a summary
+      extra = ""
+      # display extra text in italic (default: true)
+      extraItalic = true
       # whether to show social links
       # 是否显示社交账号
       social = true

--- a/hugo.toml
+++ b/hugo.toml
@@ -191,6 +191,10 @@
       # whether to use typeit animation for subtitle
       # 是否为副标题显示打字机动画
       typeit = true
+      # you can add extra information after the subtitle, such as citations or a summary
+      extra = ""
+      # display extra text in italic (default: true)
+      extraItalic = true
       # whether to show social links
       # 是否显示社交账号
       social = true

--- a/layouts/partials/home/profile.html
+++ b/layouts/partials/home/profile.html
@@ -39,6 +39,12 @@
         </div>
     {{- end -}}
 
+    {{- with $profile.extra -}}
+        <p class="home-extra{{ if not  $profile.extraItalic }} no-italic{{ end }}">
+            {{- . | safeHTML -}}
+        </p>
+    {{- end -}}
+
     {{- if $profile.social -}}
         <div class="links">
             {{- $socialMap := resources.Get "data/social.yml" | transform.Unmarshal -}}


### PR DESCRIPTION
This PR introduces a new extra field in the site's profile configuration, allowing users to add an extra line of text below the subtitle on the homepage. This field is highly flexible and can be used for various purposes, such as adding a citation, a short summary, or any other relevant information to enhance the site's front page.