### PR TITLE
fix(giscus): add support for strict mapping parameter

### DIFF
--- a/layouts/partials/comment.html
+++ b/layouts/partials/comment.html
@@ -136,6 +136,7 @@
             {{- $commentConfig = dict "categoryId" $giscus.categoryId | dict "giscus" | merge $commentConfig -}}
             {{- $commentConfig = $giscus.lang | default (T "valineLang") | dict "lang" | dict "giscus" | merge $commentConfig -}}
             {{- $commentConfig = $giscus.mapping | default "pathname" | dict "mapping" | dict "giscus" | merge $commentConfig -}}
+            {{- $commentConfig = $giscus.strict | default "0" | dict "strict" | dict "giscus" | merge $commentConfig -}}
             {{- $commentConfig = $giscus.reactionsEnabled | default "1" | dict "reactionsEnabled" | dict "giscus" | merge $commentConfig -}}
             {{- $commentConfig = $giscus.emitMetadata | default "0" | dict "emitMetadata" | dict "giscus" | merge $commentConfig -}}
             {{- $commentConfig = $giscus.inputPosition | default "bottom" | dict "inputPosition" | dict "giscus" | merge $commentConfig -}}

--- a/src/js/theme.js
+++ b/src/js/theme.js
@@ -633,6 +633,7 @@ class Theme {
                 giscusScript.setAttribute('data-category-id', giscusConfig.categoryId);
                 giscusScript.setAttribute('data-lang', giscusConfig.lang);
                 giscusScript.setAttribute('data-mapping', giscusConfig.mapping);
+                if (giscusConfig.strict) giscusScript.setAttribute('data-strict', giscusConfig.strict);
                 giscusScript.setAttribute('data-reactions-enabled', giscusConfig.reactionsEnabled);
                 giscusScript.setAttribute('data-emit-metadata', giscusConfig.emitMetadata);
                 giscusScript.setAttribute('data-input-position', giscusConfig.inputPosition);


### PR DESCRIPTION
The theme's JavaScript did not read or apply the `strict` parameter from the site config, preventing the use of Giscus's strict mapping feature.

On multilingual sites using `pathname` mapping, this default fuzzy matching could cause incorrect discussion mapping. For example, a page at `/about/` could incorrectly load the discussion for a page at `/zh-cn/about/`.

This commit resolves the issue by:
1.  Ensuring the `strict` parameter is passed from the Hugo template (`comment.html`) to the global config object.
2.  Updating `theme.js` to read this `strict` value and set the `data-strict` attribute on the dynamically generated Giscus script tag.

This allows users to enable exact matching by setting `strict = "1"` in their config, fixing the multilingual comment issue.