### PR TITLE
feat: add Content-Security-Policy meta tag support (#983)

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -217,6 +217,13 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
     # Windows v8-11 磁贴颜色
     tileColor = "#da532c"
 
+  # Security config
+  # 安全配置
+  [params.security]
+    # Content-Security-Policy meta tag for when HTTP headers cannot be set
+    # https://content-security-policy.com/examples/meta/
+    # contentSecurityPolicy = "default-src 'self'"
+
   # Search config
   # 搜索配置
   [params.search]

--- a/hugo.toml
+++ b/hugo.toml
@@ -136,6 +136,14 @@
     # Windows v8-11 磁贴颜色
     tileColor = "#da532c"
 
+  # Security config
+  # 安全配置
+  [params.security]
+    # Content-Security-Policy meta tag for when HTTP headers cannot be set
+    # https://content-security-policy.com/examples/meta/
+    # 当无法设置 HTTP 响应头时使用的 Content-Security-Policy meta 标签
+    # contentSecurityPolicy = "default-src 'self'"
+
   # Search config
   # 搜索配置
   [params.search]

--- a/layouts/_partials/head/meta.html
+++ b/layouts/_partials/head/meta.html
@@ -15,3 +15,8 @@
 {{- with .Site.Params.app.tileColor -}}
     <meta name="msapplication-TileColor" content="{{ . }}">
 {{- end -}}
+
+{{- /* Content-Security-Policy meta tag (when HTTP headers cannot be set) - see https://content-security-policy.com/examples/meta/ */ -}}
+{{- with .Site.Params.security.contentSecurityPolicy -}}
+    <meta http-equiv="Content-Security-Policy" content="{{ . }}">
+{{- end -}}


### PR DESCRIPTION
## Summary
Add `params.security.contentSecurityPolicy` option to output Content-Security-Policy via meta tag when HTTP headers cannot be set (e.g. static hosting without header control).

Fixes #983

## Changes
- `layouts/_partials/head/meta.html` – Output `<meta http-equiv="Content-Security-Policy" content="...">` when configured
- `hugo.toml` – Add `[params.security]` section with `contentSecurityPolicy` option
- `exampleSite/hugo.toml` – Same for consistency

## Usage

```toml
[params.security]
  contentSecurityPolicy = "default-src 'self'; script-src 'self' 'unsafe-inline'"
```

Ref: https://content-security-policy.com/examples/meta/
