### PR TITLE
feat(posts): add two-column layout option with toggle for all list pages

### DIFF
--- a/assets/css/_page/_archive.scss
+++ b/assets/css/_page/_archive.scss
@@ -3,6 +3,60 @@
     text-align: right;
   }
 
+  .columns-toggle {
+    float: right;
+    display: inline-flex;
+    padding: .5rem 0;
+
+    .columns-toggle-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      height: 2rem;
+      border: 1px solid $global-border-color;
+      background: transparent;
+      color: $global-font-secondary-color;
+      cursor: pointer;
+      font-size: .875rem;
+      transition: all 0.2s ease;
+
+      &:first-child {
+        border-radius: .25rem 0 0 .25rem;
+      }
+
+      &:last-child {
+        border-radius: 0 .25rem .25rem 0;
+        border-left: none;
+      }
+
+      &:hover {
+        color: $global-link-hover-color;
+      }
+
+      &.active {
+        background: $global-link-color;
+        color: #fff;
+        border-color: $global-link-color;
+      }
+
+      [theme=dark] & {
+        border-color: $global-border-color-dark;
+        color: $global-font-secondary-color-dark;
+
+        &:hover {
+          color: $global-link-hover-color-dark;
+        }
+
+        &.active {
+          background: $global-link-color-dark;
+          color: #fff;
+          border-color: $global-link-color-dark;
+        }
+      }
+    }
+  }
+
   .group-title {
     margin-top: 1.5rem;
     margin-bottom: 1rem;

--- a/assets/css/_page/_home.scss
+++ b/assets/css/_page/_home.scss
@@ -78,6 +78,72 @@
     width: 6rem;
   }
 
+  .columns-toggle {
+    display: flex;
+    justify-content: flex-end;
+    padding: .5rem 0;
+
+    .columns-toggle-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      height: 2rem;
+      border: 1px solid $global-border-color;
+      background: transparent;
+      color: $global-font-secondary-color;
+      cursor: pointer;
+      font-size: .875rem;
+      transition: all 0.2s ease;
+
+      &:first-child {
+        border-radius: .25rem 0 0 .25rem;
+      }
+
+      &:last-child {
+        border-radius: 0 .25rem .25rem 0;
+        border-left: none;
+      }
+
+      &:hover {
+        color: $global-link-hover-color;
+      }
+
+      &.active {
+        background: $global-link-color;
+        color: #fff;
+        border-color: $global-link-color;
+      }
+
+      [theme=dark] & {
+        border-color: $global-border-color-dark;
+        color: $global-font-secondary-color-dark;
+
+        &:hover {
+          color: $global-link-hover-color-dark;
+        }
+
+        &.active {
+          background: $global-link-color-dark;
+          color: #fff;
+          border-color: $global-link-color-dark;
+        }
+      }
+    }
+  }
+
+  .home-posts-grid {
+    &[data-columns="2"] {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 0 1.5rem;
+
+      @media only screen and (max-width: 680px) {
+        grid-template-columns: 1fr;
+      }
+    }
+  }
+
   .summary {
     padding-top: 1rem;
     padding-bottom: .8rem;

--- a/assets/css/_partial/_archive/_terms.scss
+++ b/assets/css/_partial/_archive/_terms.scss
@@ -39,6 +39,18 @@
   }
 }
 
+.archive-items-grid {
+  &[data-columns="2"] {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0 1.5rem;
+
+    @media only screen and (max-width: 680px) {
+      grid-template-columns: 1fr;
+    }
+  }
+}
+
 .archive-item {
   display: flex;
   justify-content: space-between;

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -181,6 +181,8 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
     # amount of RSS pages
     # RSS 文章数目
     rss = 10
+    # number of columns [1, 2] / 列数 [1, 2]
+    columns = 2
 
   # List (category or tag) page config
   # List (目录或标签) 页面配置
@@ -194,6 +196,8 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
     # amount of RSS pages
     # RSS 文章数目
     rss = 10
+    # number of columns [1, 2] / 列数 [1, 2]
+    columns = 2
 
   # App icon config
   # 应用图标配置
@@ -298,6 +302,8 @@ ignoreErrors = ["error-remote-getjson", "error-missing-instagram-accesstoken"]
       # special amount of posts in each home posts page
       # 主页每页显示文章数量
       paginate = 6
+      # number of columns [1, 2] / 列数 [1, 2]
+      columns = 2
   # Social config in home page
   # 主页的社交信息设置
   [params.social]

--- a/hugo.toml
+++ b/hugo.toml
@@ -100,6 +100,8 @@
     # amount of RSS pages
     # RSS 文章数目
     rss = 10
+    # number of columns [1, 2] / 列数 [1, 2]
+    columns = 1
 
   # List (category or tag) page config
   # List (目录或标签) 页面配置
@@ -113,6 +115,8 @@
     # amount of RSS pages
     # RSS 文章数目
     rss = 10
+    # number of columns [1, 2] / 列数 [1, 2]
+    columns = 1
 
   # App icon config
   # 应用图标配置
@@ -217,6 +221,8 @@
       # special amount of posts in each home posts page
       # 主页每页显示文章数量
       paginate = 6
+      # number of columns [1, 2] / 列数 [1, 2]
+      columns = 1
   # Social config in home page
   # 主页的社交信息设置
   [params.social]

--- a/layouts/_partials/columns-toggle.html
+++ b/layouts/_partials/columns-toggle.html
@@ -1,0 +1,44 @@
+{{- /* Column toggle: segmented pill with list/grid icons */ -}}
+{{- /* @param .columns  default column count (1 or 2) from config */ -}}
+{{- /* @param .target   CSS selector of the grid container(s) to toggle */ -}}
+{{- $columns := .columns | default 1 -}}
+{{- $target := .target -}}
+<div class="columns-toggle" data-target="{{ $target }}" data-default-columns="{{ $columns }}">
+    <button class="columns-toggle-btn{{ if ne (int $columns) 2 }} active{{ end }}" data-columns="1"
+            title="{{ T "singleColumn" | default "Single column" }}">
+        <i class="fas fa-list" aria-hidden="true"></i>
+    </button>
+    <button class="columns-toggle-btn{{ if eq (int $columns) 2 }} active{{ end }}" data-columns="2"
+            title="{{ T "twoColumns" | default "Two columns" }}">
+        <i class="fas fa-th-large" aria-hidden="true"></i>
+    </button>
+</div>
+<script>
+    (function() {
+        var wrapper = document.currentScript.previousElementSibling;
+        var target = wrapper.getAttribute('data-target');
+        var defaultCols = parseInt(wrapper.getAttribute('data-default-columns')) || 1;
+        var storageKey = 'columns-' + target;
+        var saved = window.localStorage && window.localStorage.getItem(storageKey);
+        var current = saved ? parseInt(saved) : defaultCols;
+        var buttons = wrapper.querySelectorAll('.columns-toggle-btn');
+
+        function apply(cols) {
+            var grids = document.querySelectorAll(target);
+            grids.forEach(function(grid) { grid.setAttribute('data-columns', cols); });
+            buttons.forEach(function(btn) {
+                btn.classList.toggle('active', parseInt(btn.getAttribute('data-columns')) === cols);
+            });
+            if (window.localStorage) window.localStorage.setItem(storageKey, cols);
+            current = cols;
+        }
+
+        apply(current);
+
+        buttons.forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                apply(parseInt(btn.getAttribute('data-columns')));
+            });
+        });
+    })();
+</script>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -32,9 +32,13 @@
             {{- else -}}
                 {{- $pages = .Paginate $pages -}}
             {{- end -}}
-            {{- range $pages.Pages -}}
-                {{- .Render "summary" -}}
-            {{- end -}}
+            {{- $columns := $posts.columns | default 1 -}}
+            {{- partial "columns-toggle.html" (dict "columns" $columns "target" ".home-posts-grid") -}}
+            <div class="home-posts-grid" data-columns="{{ $columns }}">
+                {{- range $pages.Pages -}}
+                    {{- .Render "summary" -}}
+                {{- end -}}
+            </div>
             {{- partial "paginator.html" . -}}
         {{- end -}}
     </div>

--- a/layouts/section.html
+++ b/layouts/section.html
@@ -17,18 +17,22 @@
             {{- else -}}
                 {{- $pages = .Paginate $pages -}}
             {{- end -}}
+            {{- $columns := .Site.Params.section.columns | default 1 -}}
+            {{- partial "columns-toggle.html" (dict "columns" $columns "target" ".archive-items-grid") -}}
             {{- range $pages.PageGroups -}}
                 <h3 class="group-title">{{ .Key }}</h3>
-                {{- range .Pages -}}
-                    <article class="archive-item">
-                        <a href="{{ .RelPermalink }}" class="archive-item-link">
-                            {{- .Title | emojify -}}
-                        </a>
-                        <span class="archive-item-date">
-                            {{- $.Site.Params.section.dateFormat | default "01-02" | .Date.Format -}}
-                        </span>
-                    </article>
-                {{- end -}}
+                <div class="archive-items-grid" data-columns="{{ $columns }}">
+                    {{- range .Pages -}}
+                        <article class="archive-item">
+                            <a href="{{ .RelPermalink }}" class="archive-item-link">
+                                {{- .Title | emojify -}}
+                            </a>
+                            <span class="archive-item-date">
+                                {{- $.Site.Params.section.dateFormat | default "01-02" | .Date.Format -}}
+                            </span>
+                        </article>
+                    {{- end -}}
+                </div>
             {{- end -}}
             {{- partial "paginator.html" . -}}
         {{- end -}}

--- a/layouts/term.html
+++ b/layouts/term.html
@@ -24,18 +24,22 @@
             {{- else -}}
                 {{- $pages = .Paginate $pages -}}
             {{- end -}}
+            {{- $columns := .Site.Params.list.columns | default 1 -}}
+            {{- partial "columns-toggle.html" (dict "columns" $columns "target" ".archive-items-grid") -}}
             {{- range $pages.PageGroups -}}
                 <h3 class="group-title">{{ .Key }}</h3>
-                {{- range .Pages -}}
-                    <article class="archive-item">
-                        <a href="{{ .RelPermalink }}" class="archive-item-link">
-                            {{- .Title | emojify -}}
-                        </a>
-                        <span class="archive-item-date">
-                            {{- $.Site.Params.list.dateFormat | default "01-02" | .Date.Format -}}
-                        </span>
-                    </article>
-                {{- end -}}
+                <div class="archive-items-grid" data-columns="{{ $columns }}">
+                    {{- range .Pages -}}
+                        <article class="archive-item">
+                            <a href="{{ .RelPermalink }}" class="archive-item-link">
+                                {{- .Title | emojify -}}
+                            </a>
+                            <span class="archive-item-date">
+                                {{- $.Site.Params.list.dateFormat | default "01-02" | .Date.Format -}}
+                            </span>
+                        </article>
+                    {{- end -}}
+                </div>
             {{- end -}}
             {{- partial "paginator.html" . -}}
         {{- end -}}


### PR DESCRIPTION
## Summary
- Adds a configurable two-column grid layout for post listings on home, section, and term (tag/category) pages, closing [#988](https://github.com/dillonzq/LoveIt/issues/988)
- Includes a toggle button (list/grid icons) that lets users switch between single and two-column views, with preference persisted via `localStorage`
- New `columns` config option (`1` or `2`) under `params.home.posts`, `params.section`, and `params.list` in `hugo.toml`

## Changes
- **New partial:** `layouts/_partials/columns-toggle.html` — reusable toggle widget with inline JS for switching columns and persisting user preference
- **Layouts updated:** `home.html`, `section.html`, `term.html` — wrap post listings in grid containers and include the toggle partial
- **Styles added:** `_home.scss`, `_archive.scss`, `_terms.scss` — toggle button styling (with dark mode support) and responsive two-column CSS grid (falls back to single column on mobile ≤680px)
- **Config:** `hugo.toml` and `exampleSite/hugo.toml` updated with new `columns` parameter

## Screenshots

<img width="1448" height="657" alt="3_9_loveit" src="https://github.com/user-attachments/assets/b368ca92-05cc-466f-9ed1-2b66f77c54aa" />

## Test plan
- [x] Verify single-column layout (default) renders correctly on home, section, and term pages
- [x] Set `columns = 2` and verify two-column grid layout on all three page types
- [x] Click toggle buttons and confirm layout switches dynamically
- [x] Refresh the page and confirm the user's column preference is persisted
- [x] Test responsive behavior: two-column grid should collapse to single column on viewports ≤680px
- [x] Verify dark mode styling for the toggle buttons

Closes #988
