### PR TITLE
feat(hook): support table render hook

### DIFF
--- a/assets/css/_page/_single.scss
+++ b/assets/css/_page/_single.scss
@@ -167,14 +167,9 @@
       }
     }
 
-    table {
-      width: 100%;
-      max-width: 100%;
-      margin: .625rem 0;
-      border-spacing: 0;
-      background: $table-background-color;
-      border-collapse: collapse;
+    .table-wrapper {
       overflow-x: auto;
+      margin: .625rem 0;
 
       &::-webkit-scrollbar {
         background-color: $table-background-color;
@@ -183,6 +178,15 @@
           background-color: $table-background-color-dark;
         }
       }
+    }
+
+    table {
+      width: 100%;
+      max-width: 100%;
+      margin: .625rem 0;
+      border-spacing: 0;
+      background: $table-background-color;
+      border-collapse: collapse;
 
       [theme=dark] & {
         background: $table-background-color-dark;

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,6 @@
 [module]
   [module.hugoVersion]
-    min = "0.128.0"
+    min = "0.134.0"
 
 [params]
   # site default theme ["auto", "light", "dark"]

--- a/layouts/_markup/render-table.html
+++ b/layouts/_markup/render-table.html
@@ -1,0 +1,1 @@
+{{- partial "plugin/table.html" . -}}

--- a/layouts/_partials/plugin/table.html
+++ b/layouts/_partials/plugin/table.html
@@ -1,0 +1,25 @@
+<div class="table-wrapper">
+  <table
+    {{- range $k, $v := .Attributes }}
+      {{- printf " %s=%q" $k $v | safeHTMLAttr -}}
+    {{- end }}>
+    <thead>
+      {{- range .THead }}
+      <tr>
+        {{- range . }}
+        <th{{ with .Alignment }} style="text-align: {{ . }}"{{ end }}>{{ .Text }}</th>
+        {{- end }}
+      </tr>
+      {{- end }}
+    </thead>
+    <tbody>
+      {{- range .TBody }}
+      <tr>
+        {{- range . }}
+        <td{{ with .Alignment }} style="text-align: {{ . }}"{{ end }}>{{ .Text }}</td>
+        {{- end }}
+      </tr>
+      {{- end }}
+    </tbody>
+  </table>
+</div>

--- a/theme.toml
+++ b/theme.toml
@@ -23,7 +23,7 @@ features = [
   "SEO Optimized"
 ]
 
-min_version = "0.128.0"
+min_version = "0.134.0"
 
 [author]
   name = "Dillon"


### PR DESCRIPTION
## Summary

- Add Hugo table render hook (`render-table.html`) to generate table markup at build time, replacing Hugo's default table rendering
- Wrap tables in a `.table-wrapper` div for proper horizontal scrolling on narrow viewports
- Apply column text alignment via inline styles from Markdown syntax

Closes #1015

## Changes

- `layouts/_markup/render-table.html` – Render hook entry point, delegates to partial
- `layouts/_partials/plugin/table.html` – Table template using `.THead` / `.TBody` context with alignment support and Markdown attribute passthrough
- `assets/css/_page/_single.scss` – Add `.table-wrapper` with `overflow-x: auto` and scrollbar styles; keep `table` base styles unchanged
- `hugo.toml` / `theme.toml` – Bump minimum Hugo version to `0.134.0` (required for table render hooks)

## Verification

Build the example site and inspect the HTML output:

```bash
hugo --source exampleSite --themesDir ../..
grep -B 1 -A 5 '<table' exampleSite/public/basic-markdown-syntax/index.html
```

Tables are now wrapped in `<div class="table-wrapper">` and alignment styles (`text-align: center`, `text-align: right`) are applied to cells.

## Screenshots

<!-- screenshots will be attached -->

<img width="1602" height="906" alt="image" src="https://github.com/user-attachments/assets/f99b19a5-8e99-465a-ade0-62626fc134c5" />

<img width="2081" height="759" alt="image" src="https://github.com/user-attachments/assets/772b19ee-403c-42ff-8ce2-94cd9855d168" />

