### PR TITLE
feat: Support passthrough render hooks for mathematics

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -2,6 +2,15 @@
   [module.hugoVersion]
     min = "0.128.0"
 
+# Goldmark passthrough extension for mathematics (Hugo 0.132.0+).
+# Used with layouts/_markup/render-passthrough.html for server-side LaTeX rendering.
+# See: https://gohugo.io/render-hooks/passthrough/ and https://gohugo.io/content-management/mathematics/
+[markup.goldmark.extensions.passthrough]
+  enable = true
+  [markup.goldmark.extensions.passthrough.delimiters]
+    block = [["\\[", "\\]"], ["$$", "$$"]]
+    inline = [["\\(", "\\)"]]
+
 [params]
   # site default theme ["auto", "light", "dark"]
   # 网站默认主题 ["auto", "light", "dark"]
@@ -360,6 +369,7 @@
       mermaid = true
     # KaTeX mathematical formulas config (KaTeX https://katex.org/)
     # KaTeX 数学公式配置 (KaTeX https://katex.org/)
+    # With Goldmark passthrough enabled above, math can also be server-rendered via render-passthrough.html (Hugo 0.132.0+).
     [params.page.math]
       enable = false
       # default inline delimiter is $ ... $ and \( ... \)

--- a/layouts/_markup/render-passthrough.html
+++ b/layouts/_markup/render-passthrough.html
@@ -1,0 +1,14 @@
+{{- /*
+  Passthrough render hook for mathematics (LaTeX).
+  Requires Hugo 0.132.0+ (transform.ToMath and passthrough render hooks).
+  See: https://gohugo.io/render-hooks/passthrough/ and https://gohugo.io/content-management/mathematics/
+*/ -}}
+{{- $opts := dict "output" "htmlAndMathml" "displayMode" (eq .Type "block") -}}
+{{- with try (transform.ToMath .Inner $opts) -}}
+  {{- with .Err -}}
+    {{- errorf "Unable to render mathematical markup (transform.ToMath): %s at %s" . $.Position -}}
+  {{- else -}}
+    {{- .Value -}}
+    {{- $.Page.Store.Set "hasMath" true -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/_partials/assets.html
+++ b/layouts/_partials/assets.html
@@ -142,6 +142,14 @@
         {{- $delimiters = $delimiters | append (dict "left" $math.inlineRightDelimiter "right" $math.inlineRightDelimiter "display" false) -}}
     {{- end -}}
     {{- $config = dict "strict" false "delimiters" $delimiters | dict "math" | merge $config -}}
+{{- else if .Store.Get "hasMath" -}}
+    {{- $source := $cdn.katexCSS | default "lib/katex/katex.min.css" -}}
+    {{- dict "Source" $source "Fingerprint" $fingerprint | dict "Scratch" .Scratch "Data" | partial "scratch/style.html" -}}
+    {{- if not $cdn.katexCSS -}}
+        {{- range resources.Match "lib/katex/fonts/*" -}}
+            {{- .Publish -}}
+        {{- end -}}
+    {{- end -}}
 {{- end -}}
 
 {{- /* mermaid */ -}}


### PR DESCRIPTION
## Description

Implements [passthrough render hooks](https://gohugo.io/render-hooks/passthrough/) for mathematics so that LaTeX in Markdown is rendered server-side with Hugo's `transform.ToMath` (KaTeX) instead of client-side JavaScript.

Closes #1021 


## Changes

- **`layouts/_markup/render-passthrough.html`** (new): Passthrough render hook that renders `\[...\]`, `$$...$$`, and `\(...\)` using `transform.ToMath` with `htmlAndMathml` output and sets `Page.Store "hasMath"` so the theme can load KaTeX CSS only when needed.
- **`layouts/_partials/assets.html`**: When a page has server-rendered math (`.Store.Get "hasMath"`) but client-side math is disabled, load only KaTeX CSS (and publish fonts) so the pre-rendered math displays correctly without loading KaTeX JS or auto-render.
- **`hugo.toml`**: Enable Goldmark passthrough extension with standard math delimiters:
  - Block: `\[...\]`, `$$...$$`
  - Inline: `\(...\)`

## Requirements

- **Hugo 0.132.0+** for passthrough render hooks and `transform.ToMath`. The theme's minimum version remains 0.128.0; sites on 0.128–0.131 will keep existing behavior (passthrough content may appear as raw text if they enable the extension).
