### PR TITLE
Unbreak Discord Server Invite Social Link

### DIFF
--- a/assets/data/social.yml
+++ b/assets/data/social.yml
@@ -504,10 +504,10 @@ discord:
     Class: fab fa-discord
 
 # 064: Discord Server Invite Link
-discordInvite:
+discordinvite:
   Weight: 64
   Prefix: https://discord.gg/
-  Title: Discord
+  Title: Discord Server Invite
   Icon:
     Class: fab fa-discord
 


### PR DESCRIPTION
The rendering in profile.html uses lowercase, and the uppercase I breaks the discordinvite. 

While there, use a different title, to make the distinction to the discord user link more obvious.