### PR TITLE
Fixed Site.LanguageCode deprecation warnings for Hugo v0.158.0 and above.

### DIFF
--- a/layouts/_partials/head/seo.html
+++ b/layouts/_partials/head/seo.html
@@ -23,7 +23,7 @@
         "@context": "http://schema.org",
         "@type": "WebSite",
         "url": "{{ .Permalink }}",
-        {{- with .Site.LanguageCode -}}
+        {{- with .Site.Language.Locale -}}
             "inLanguage": "{{ . }}",
         {{- end -}}
         {{- with .Site.Params.Author.name -}}
@@ -69,7 +69,7 @@
         "@context": "http://schema.org",
         "@type": "BlogPosting",
         "headline": {{ .Title | safeHTML }},
-        "inLanguage": "{{ .Site.LanguageCode }}",
+        "inLanguage": "{{ .Site.Language.Locale }}",
         "mainEntityOfPage": {
             "@type": "WebPage",
             "@id": "{{ .Permalink }}"

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,7 +1,7 @@
 {{- partial "init.html" . -}}
 
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/layouts/home.rss.xml
+++ b/layouts/home.rss.xml
@@ -10,7 +10,7 @@
             {{- .Site.Params.description | default .Site.Title -}}
         </description>
         <generator>Hugo -- gohugo.io</generator>
-        {{- with .Site.LanguageCode -}}
+        {{- with .Site.Language.Locale -}}
             <language>
                 {{- . -}}
             </language>

--- a/layouts/posts/rss.xml
+++ b/layouts/posts/rss.xml
@@ -10,7 +10,7 @@
             {{- .Params.Title | default (T .Section) | default .Section | dict "Some" | T "allSome" }} | {{ .Site.Title -}}
         </description>
         <generator>Hugo -- gohugo.io</generator>
-        {{- with .Site.LanguageCode -}}
+        {{- with .Site.Language.Locale -}}
             <language>
                 {{- . -}}
             </language>

--- a/layouts/term.rss.xml
+++ b/layouts/term.rss.xml
@@ -10,7 +10,7 @@
             {{- .Title }} - {{ T .Data.Singular | default .Data.Singular }} - {{ .Site.Title -}}
         </description>
         <generator>Hugo -- gohugo.io</generator>
-        {{- with .Site.LanguageCode -}}
+        {{- with .Site.Language.Locale -}}
             <language>
                 {{- . -}}
             </language>


### PR DESCRIPTION
Just minor search/replace fix to get rid of Hugo deprecation warnings.